### PR TITLE
API refactoring, fmin_cobyla removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## [Unreleased]
+
+* Remove `fmin_cobyla` implementation as `nlopt_cobyla` now renamed `minimize` based on NLopt implementation is more powerful
+Nevertheless Cobyla argmin solver is still based on initial implementation, not on NLopt one.
+* Remove gradient from `ObjFn` trait which is now renamed `Func`
+
+## [0.4.0] - 2023-10-06
+
+COBYLA implementation coming from the NLopt project is now also available (as `nlopt_cobyla`) allowing to compare 
+with the initial implementation (`fmin_cobyla`). This new implementation went through the same process of using c2rust
+transpilation from initial C implementation.
+
+## [0.3.0] - 2023-01-28
+
+COBYLA is now also implemented as an argmin::Solver to benefit from [argmin framework](https://github.com/argmin-rs) tooling. See [example](./examples/paraboloid.rs)
+
+## [0.2.0] - 2023-01-09
+
+COBYLA C code has been translated to Rust using [c2rust](https://github.com/immunant/c2rust) then manually edited.
+
+## [0.1.0] - 2022-05-06
+
+Rust wrapper for COBYLA optimizer (COBYLA stands for Constrained Optimization BY Linear Approximations). 
+COBYLA C code was copied from [here](https://github.com/emmt/Algorithms/tree/master/cobyla) and wrapped 
+using the callback trick implemented in [nlopt-rust](https://github.com/adwhit/rust-nlopt) project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove `fmin_cobyla` implementation as `nlopt_cobyla` now renamed `minimize` based on NLopt implementation is more powerful
 Nevertheless Cobyla argmin solver is still based on initial implementation, not on NLopt one.
 * Remove gradient from `ObjFn` trait which is now renamed `Func`
+* `minimize` API rework to make it more Rusty
 
 ## [0.4.0] - 2023-10-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Remi Lafage <remi.lafage@onera.fr>"]
 name = "cobyla"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 edition = "2021"
 license-file = "LICENSE.md"
 description = "COBYLA optimizer for Rust"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,19 +1,22 @@
 
 
-The following licenses apply to the code in this repository:
+Copyright (c) 2020-2023 Rémi Lafage
 
-    Copyright (C) 1992, Mike J. D. Powell: COBYLA algorithm in FORTRAN released under the GNU Lesser General Public License.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-    Copyright (C) 2015-2017, Éric Thiébaut: COBYLA C code released under the MIT "Expat" License (see below).
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-    Copyright (C) 2020-2021, Rémi Lafage: COBYLA Rust wrapper released under the MIT "Expat" License (see below).
-
-
-The MIT "Expat" License (MIT):
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,38 +4,14 @@
 [![crates.io](https://img.shields.io/crates/v/cobyla)](https://crates.io/crates/cobyla)
 [![docs](https://docs.rs/cobyla/badge.svg)](https://docs.rs/cobyla)
 
-COBYLA an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed) 
-and take into account constraints on the variables. The algorithm is described in:
+COBYLA an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed) and take into account constraints on the variables. The algorithm is described in:
 
   > M.J.D. Powell, "A direct search optimization method that models the objective and constraint functions by linear interpolation," in 
   > Advances in Optimization and Numerical Analysis Mathematics and Its Applications, vol. 275 (eds. Susana Gomez and Jean-Pierre Hennart), 
   > Kluwer Academic Publishers, pp. 51-67 (1994).
 
-## cobyla 0.4.x
-
-COBYLA implementation coming from the NLopt project is now also available (as `nlopt_cobyla`) allowing to compare 
-with the initial implementation (`fmin_cobyla`). This new implementation went through the same process of using c2rust
-transpilation from initial C implementation.
+## Example
 
 ```bash
 cargo run --example paraboloid
 ```
-
-## cobyla 0.3.x
-
-COBYLA is now also implemented as an argmin::Solver to benefit from [argmin framework](https://github.com/argmin-rs) tooling. See [example](./examples/paraboloid.rs)
-
-```bash
-cargo run --example paraboloid
-```
-
-## cobyla 0.2.x
-
-COBYLA C code has been translated to Rust using [c2rust](https://github.com/immunant/c2rust) then manually edited.
-
-## cobyla 0.1.x
-
-Rust wrapper for COBYLA optimizer (COBYLA stands for Constrained Optimization BY Linear Approximations). 
-COBYLA C code was copied from [here](https://github.com/emmt/Algorithms/tree/master/cobyla) and wrapped 
-using the callback trick implemented in [nlopt-rust](https://github.com/adwhit/rust-nlopt) project.
-

--- a/README.md
+++ b/README.md
@@ -1,17 +1,34 @@
-# cobyla
+# cobyla - a pure Rust implementation
 
 [![tests](https://github.com/relf/cobyla/workflows/tests/badge.svg)](https://github.com/relf/cobyla/actions?query=workflow%3Atests)
 [![crates.io](https://img.shields.io/crates/v/cobyla)](https://crates.io/crates/cobyla)
 [![docs](https://docs.rs/cobyla/badge.svg)](https://docs.rs/cobyla)
 
-COBYLA an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed) and take into account constraints on the variables. The algorithm is described in:
+COBYLA is an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed) and take into account constraints on the variables. The algorithm is described in:
 
   > M.J.D. Powell, "A direct search optimization method that models the objective and constraint functions by linear interpolation," in 
   > Advances in Optimization and Numerical Analysis Mathematics and Its Applications, vol. 275 (eds. Susana Gomez and Jean-Pierre Hennart), 
   > Kluwer Academic Publishers, pp. 51-67 (1994).
+
+The algorithm comes into two flavours :
+* As an [argmin solver](), the Rust code was generated from the C code from [here](https://github.com/emmt/Algorithms/tree/master/cobyla) 
+* As a function `minimize`, the Rust code was generated from the C code the [NLopt](https://github.com/stevengj/nlopt) project (version 2.7.1)  
+
+In both cases, an initial transpilation was done with [c2rust](https://github.com/immunant/c2rust) then the code was manually edited to make it work. Note that the callback mechanism
+is inspired from the excellent Rust binding of NLopt, namely [rust-nlopt](https://github.com/adwhit/rust-nlopt)
 
 ## Example
 
 ```bash
 cargo run --example paraboloid
 ```
+
+## Related projects
+
+* [rust-nlopt](https://github.com/adwhit/rust-nlopt): the Rust binding of the [NLopt project](https://nlopt.readthedocs.io)
+* [argmin](https://github.com/argmin-rs/argmin): the pure-Rust optimization framework
+* [slsqp](https://github.com/relf/slsqp): As for `cobyla`, a pure Rust implementation of SLSQP transpiled and manually edited from NLopt C code. 
+
+## License
+
+The project is released under MIT License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![crates.io](https://img.shields.io/crates/v/cobyla)](https://crates.io/crates/cobyla)
 [![docs](https://docs.rs/cobyla/badge.svg)](https://docs.rs/cobyla)
 
-COBYLA is an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed) and take into account constraints on the variables. The algorithm is described in:
+COBYLA is an algorithm for minimizing a function of many variables. The method is derivatives-free (only the function values are needed) 
+and take into account constraints on the variables. The algorithm is described in:
 
   > M.J.D. Powell, "A direct search optimization method that models the objective and constraint functions by linear interpolation," in 
   > Advances in Optimization and Numerical Analysis Mathematics and Its Applications, vol. 275 (eds. Susana Gomez and Jean-Pierre Hennart), 
@@ -14,8 +15,8 @@ The algorithm comes into two flavours :
 * As an [argmin solver](), the Rust code was generated from the C code from [here](https://github.com/emmt/Algorithms/tree/master/cobyla) 
 * As a function `minimize`, the Rust code was generated from the C code the [NLopt](https://github.com/stevengj/nlopt) project (version 2.7.1)  
 
-In both cases, an initial transpilation was done with [c2rust](https://github.com/immunant/c2rust) then the code was manually edited to make it work. Note that the callback mechanism
-is inspired from the excellent Rust binding of NLopt, namely [rust-nlopt](https://github.com/adwhit/rust-nlopt)
+In both cases, an initial transpilation was done with [c2rust](https://github.com/immunant/c2rust) then the code was manually edited to make it work. 
+The callback mechanismn is inspired from the Rust binding of NLopt, namely [rust-nlopt](https://github.com/adwhit/rust-nlopt)
 
 ## Example
 
@@ -27,7 +28,7 @@ cargo run --example paraboloid
 
 * [rust-nlopt](https://github.com/adwhit/rust-nlopt): the Rust binding of the [NLopt project](https://nlopt.readthedocs.io)
 * [argmin](https://github.com/argmin-rs/argmin): the pure-Rust optimization framework
-* [slsqp](https://github.com/relf/slsqp): As for `cobyla`, a pure Rust implementation of SLSQP transpiled and manually edited from NLopt C code. 
+* [slsqp](https://github.com/relf/slsqp): a pure Rust implementation of the SLSQP algorithm. 
 
 ## License
 

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -20,16 +20,17 @@ impl CostFunction for ParaboloidProblem {
 }
 
 fn main() {
-    let xinit = vec![1., 1.];
-
     println!("*** Solve paraboloid problem using nlopt_cobyla");
+
+    // Initial guess
+    let xinit = vec![1., 1.];
 
     // Define a constraint: x0 > 0
     let mut cons: Vec<&dyn Func<()>> = vec![];
     let cstr1 = |x: &[f64], _u: &mut ()| x[0];
     cons.push(&cstr1);
 
-    // Define a stop criterion on objective function change
+    // Define a stopping criterion on objective function change
     let stop_tol = StopTols {
         ftol_rel: 1e-4,
         ..StopTols::default()

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -7,10 +7,6 @@ fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
     10. * (x[0] + 1.).powf(2.) + x[1].powf(2.)
 }
 
-fn nlopt_paraboloid(x: &[f64], _g: Option<&mut [f64]>, _user_data: &mut ()) -> f64 {
-    paraboloid(x, &mut ())
-}
-
 /// Problem Definition: minimize paraboloid(x) subject to x0 >= 0
 struct ParaboloidProblem;
 impl CostFunction for ParaboloidProblem {
@@ -28,11 +24,11 @@ fn main() {
 
     println!("*** Solve paraboloid problem using nlopt_cobyla");
     let mut cons: Vec<&dyn Func<()>> = vec![];
-    let cstr1 = |x: &[f64], _g: Option<&mut [f64]>, _u: &mut ()| x[0];
+    let cstr1 = |x: &[f64], _u: &mut ()| x[0];
     cons.push(&cstr1);
 
     let (status, x_opt) = minimize(
-        nlopt_paraboloid,
+        paraboloid,
         &mut x,
         &cons,
         (),

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -1,6 +1,6 @@
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor};
-use cobyla::{fmin_cobyla, nlopt_cobyla, CobylaSolver, Func, NLoptObjFn};
+use cobyla::{minimize, CobylaSolver, Func};
 
 /// Problem cost function
 fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
@@ -26,24 +26,12 @@ impl CostFunction for ParaboloidProblem {
 fn main() {
     let mut x = vec![1., 1.];
 
-    println!("*** Solve paraboloid problem using Cobyla fmin_cobyla implementation");
-    // Constraint definition x0 shoulb be positive in the end
-    let mut cons: Vec<&dyn Func<()>> = vec![];
-    let cstr1 = |x: &[f64], _u: &mut ()| x[0];
-    cons.push(&cstr1);
-
-    let (status, x_opt) = fmin_cobyla(paraboloid, &mut x, &cons, (), 0.5, 1e-4, 200, 0);
-
-    // For status meaning see cobyla/cobyla.h
-    println!("status = {}", status);
-    println!("x = {:?}\n\n", x_opt);
-
     println!("*** Solve paraboloid problem using nlopt_cobyla");
-    let mut cons: Vec<&dyn NLoptObjFn<()>> = vec![];
+    let mut cons: Vec<&dyn Func<()>> = vec![];
     let cstr1 = |x: &[f64], _g: Option<&mut [f64]>, _u: &mut ()| x[0];
     cons.push(&cstr1);
 
-    let (status, x_opt) = nlopt_cobyla(
+    let (status, x_opt) = minimize(
         nlopt_paraboloid,
         &mut x,
         &cons,

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -30,9 +30,9 @@ fn main() {
     match minimize(
         paraboloid,
         &mut x,
+        &[(-10., 10.), (-10., 10.)],
         &cons,
         (),
-        &[(-10., 10.)],
         0.0,
         1e-4,
         0.0,

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -20,7 +20,7 @@ impl CostFunction for ParaboloidProblem {
 }
 
 fn main() {
-    let mut x = vec![1., 1.];
+    let xinit = vec![1., 1.];
 
     println!("*** Solve paraboloid problem using nlopt_cobyla");
     let mut cons: Vec<&dyn Func<()>> = vec![];
@@ -29,7 +29,7 @@ fn main() {
 
     match minimize(
         paraboloid,
-        &mut x,
+        &xinit,
         &[(-10., 10.), (-10., 10.)],
         &cons,
         (),

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -27,21 +27,26 @@ fn main() {
     let cstr1 = |x: &[f64], _u: &mut ()| x[0];
     cons.push(&cstr1);
 
-    let (status, x_opt) = minimize(
+    match minimize(
         paraboloid,
         &mut x,
         &cons,
         (),
-        0.5,
+        &[(-10., 10.)],
+        0.0,
         1e-4,
+        0.0,
+        &[0.0, 0.0],
         200,
-        0,
-        (-10., 10.),
-    );
-
-    // For status meaning see cobyla/nlopt/nlopt.h
-    println!("status = {}", status);
-    println!("x = {:?}\n\n", x_opt);
+        0.5,
+    ) {
+        Ok((status, x_opt, y_opt)) => {
+            println!("status = {:?}", status);
+            println!("x_opt = {:?}", x_opt);
+            println!("y_opt = {}", y_opt);
+        }
+        Err((e, _, _)) => println!("Optim error: {:?}", e),
+    }
 
     println!(
         "*** Solve paraboloid problem using Cobyla argmin solver implemented on top of fmin_cobyla impl"

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -1,6 +1,6 @@
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor};
-use cobyla::{minimize, CobylaSolver, Func};
+use cobyla::{minimize, CobylaSolver, Func, StopTols};
 
 /// Problem cost function
 fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
@@ -23,9 +23,17 @@ fn main() {
     let xinit = vec![1., 1.];
 
     println!("*** Solve paraboloid problem using nlopt_cobyla");
+
+    // Define a constraint: x0 > 0
     let mut cons: Vec<&dyn Func<()>> = vec![];
     let cstr1 = |x: &[f64], _u: &mut ()| x[0];
     cons.push(&cstr1);
+
+    // Define a stop criterion on objective function change
+    let stop_tol = StopTols {
+        ftol_rel: 1e-4,
+        ..StopTols::default()
+    };
 
     match minimize(
         paraboloid,
@@ -33,12 +41,9 @@ fn main() {
         &[(-10., 10.), (-10., 10.)],
         &cons,
         (),
-        0.0,
-        1e-4,
-        0.0,
-        &[0.0, 0.0],
         200,
         0.5,
+        Some(stop_tol),
     ) {
         Ok((status, x_opt, y_opt)) => {
             println!("status = {:?}", status);

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -1,6 +1,6 @@
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor};
-use cobyla::{fmin_cobyla, nlopt_cobyla, CobylaSolver, CstrFn, NLoptObjFn};
+use cobyla::{fmin_cobyla, nlopt_cobyla, CobylaSolver, Func, NLoptObjFn};
 
 /// Problem cost function
 fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
@@ -28,7 +28,7 @@ fn main() {
 
     println!("*** Solve paraboloid problem using Cobyla fmin_cobyla implementation");
     // Constraint definition x0 shoulb be positive in the end
-    let mut cons: Vec<&dyn CstrFn<()>> = vec![];
+    let mut cons: Vec<&dyn Func<()>> = vec![];
     let cstr1 = |x: &[f64], _u: &mut ()| x[0];
     cons.push(&cstr1);
 

--- a/examples/paraboloid.rs
+++ b/examples/paraboloid.rs
@@ -1,6 +1,6 @@
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor};
-use cobyla::{minimize, CobylaSolver, Func, StopTols};
+use cobyla::{minimize, CobylaSolver, Func, RhoBeg, StopTols};
 
 /// Problem cost function
 fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
@@ -42,7 +42,7 @@ fn main() {
         &cons,
         (),
         200,
-        0.5,
+        RhoBeg::All(0.5),
         Some(stop_tol),
     ) {
         Ok((status, x_opt, y_opt)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use std::os::raw::c_void;
 /// ```
 /// use cobyla::{minimize, Func};
 ///
-/// fn paraboloid(x: &[f64], _g: Option<&mut [f64]>, _data: &mut ()) -> f64 {
+/// fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
 ///     10. * (x[0] + 1.).powf(2.) + x[1].powf(2.)
 /// }
 ///
@@ -35,8 +35,8 @@ use std::os::raw::c_void;
 ///
 /// // Constraints definition to be positive eventually
 /// let mut cons: Vec<&dyn Func<()>> = vec![];
-/// cons.push(&|x: &[f64], _g: Option<&mut [f64]>, _data: &mut ()| x[1] - x[0] * x[0]);
-/// cons.push(&|x: &[f64], _g: Option<&mut [f64]>, _data: &mut ()| 1. - x[0] * x[0] - x[1] * x[1]);
+/// cons.push(&|x: &[f64], _data: &mut ()| x[1] - x[0] * x[0]);
+/// cons.push(&|x: &[f64], _data: &mut ()| 1. - x[0] * x[0] - x[1] * x[1]);
 ///
 /// let (status, x_opt) = minimize(paraboloid, &mut x, &cons, (), 0.5, 1e-4, 200, 0, (-10., 10.));
 /// println!("status = {}", status);
@@ -312,7 +312,7 @@ mod tests {
         assert_abs_diff_eq!(x.as_slice(), [-1., 0.].as_slice(), epsilon = 1e-4);
     }
 
-    fn paraboloid(x: &[f64], _g: Option<&mut [f64]>, _data: &mut ()) -> f64 {
+    fn paraboloid(x: &[f64], _data: &mut ()) -> f64 {
         10. * (x[0] + 1.).powf(2.) + x[1].powf(2.)
     }
 
@@ -322,7 +322,7 @@ mod tests {
 
         // #[allow(bare_trait_objects)]
         let mut cons: Vec<&dyn Func<()>> = vec![];
-        let cstr1 = |x: &[f64], _g: Option<&mut [f64]>, _user_data: &mut ()| x[0];
+        let cstr1 = |x: &[f64], _user_data: &mut ()| x[0];
         cons.push(&cstr1 as &dyn Func<()>);
 
         // x_opt = [0, 0]
@@ -334,14 +334,14 @@ mod tests {
         assert_abs_diff_eq!(x.as_slice(), [0., 0.].as_slice(), epsilon = 1e-3);
     }
 
-    fn fletcher9115(x: &[f64], _g: Option<&mut [f64]>, _user_data: &mut ()) -> f64 {
+    fn fletcher9115(x: &[f64], _user_data: &mut ()) -> f64 {
         -x[0] - x[1]
     }
 
-    fn cstr1(x: &[f64], _g: Option<&mut [f64]>, _user_data: &mut ()) -> f64 {
+    fn cstr1(x: &[f64], _user_data: &mut ()) -> f64 {
         x[1] - x[0] * x[0]
     }
-    fn cstr2(x: &[f64], _g: Option<&mut [f64]>, _user_data: &mut ()) -> f64 {
+    fn cstr2(x: &[f64], _user_data: &mut ()) -> f64 {
         1. - x[0] * x[0] - x[1] * x[1]
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,5 @@
-//! cobyla
-//!
-//! COBYLA is an algorithm for minimizing a function of many variables. The method is derivatives free (only the function values are needed)
-//! and take into account constraints on the variables. The algorithm is described in:
-//!
-//! > M.J.D. Powell, "A direct search optimization method that models the objective and constraint functions by linear interpolation," in
-//! > Advances in Optimization and Numerical Analysis Mathematics and Its Applications, vol. 275 (eds. Susana Gomez and Jean-Pierre Hennart),
-//! > Kluwer Academic Publishers, pp. 51-67 (1994).
-//!
-//! The objective function to be minimized has to implement the [`ObjFn`] trait, while constraints,
-//! also defined as functions of the input variables have to implement the [`CstrFn`] trait.
-//! Constraints values are intended to be positive at the end of the optimization.
-//!
-//! The algorithm can be run either using the [`fmin_cobyla`] function or using the [`CobylaSolver`]
-//! which leverages the [argmin](https://www.argmin-rs.org/book/index.html) framework.
-//!
-//! Another COBYLA implementation coming from the [NLopt] project is also available as [`nlopt_cobyla`], this one is not yet
-//! wrapped as an argmin solver.
-//!
-//! Implementation Notes:
-//!
-//! 0.4.x : COBYLA NLopt 2.7.1 implementation is now available as [`nlopt_cobyla`] function. As for the original implementation
-//! [`fmin_cobyla`], it was first generated from C code using c2rust then manually edited to make it work.
-//!
-//! 0.3.x : COBYLA is now also implemented as an argmin::Solver and benefits from [argmin framework](https://github.com/argmin-rs) tooling.
-//!
-//! 0.2.x : The C code is now translated in Rust using c2rust transpiler then manually edited to avoid FFI usage
-//! to get Rust (unsafe) implementation.
-//!  
-//! 0.1.x : the C code is wrapped with with bindgen is visible as the `raw_cobyla` function using the callback type
-//! `cobyla_calcfc` which is used to compute the objective function and the constraints.
-//!
+#![doc = include_str!("../README.md")]
+
 mod cobyla;
 use nlopt_cobyla::nlopt_constraint;
 

--- a/src/nlopt_cobyla.rs
+++ b/src/nlopt_cobyla.rs
@@ -79,7 +79,7 @@ pub struct NLoptConstraintCfg<F: Func<T>, T> {
 /// An objective function takes the form of a closure `f(x: &[f64], user_data: &mut U) -> f64`
 ///
 /// * `x` - `n`-dimensional array
-/// * `user_data` - user defined data
+/// * `user_data` - user defined data for objective and constraint functions
 pub trait Func<U>: Fn(&[f64], &mut U) -> f64 {}
 impl<T, U> Func<U> for T where T: Fn(&[f64], &mut U) -> f64 {}
 

--- a/src/nlopt_cobyla.rs
+++ b/src/nlopt_cobyla.rs
@@ -27,20 +27,20 @@ use std::slice;
 pub fn nlopt_function_raw_callback<F: Func<T>, T>(
     n: libc::c_uint,
     x: *const f64,
-    g: *mut f64,
+    _g: *mut f64,
     params: *mut libc::c_void,
 ) -> f64 {
     // prepare args
     let argument = unsafe { slice::from_raw_parts(x, n as usize) };
-    let gradient = if g.is_null() {
-        None
-    } else {
-        Some(unsafe { slice::from_raw_parts_mut(g, n as usize) })
-    };
+    // let gradient = if g.is_null() {
+    //     None
+    // } else {
+    //     Some(unsafe { slice::from_raw_parts_mut(g, n as usize) })
+    // };
 
     // recover FunctionCfg object from supplied params and call
     let f = unsafe { &mut *(params as *mut NLoptFunctionCfg<F, T>) };
-    let res = (f.objective_fn)(argument, gradient, &mut f.user_data);
+    let res = (f.objective_fn)(argument, &mut f.user_data);
     #[allow(forgetting_references)]
     std::mem::forget(f);
     res
@@ -49,17 +49,18 @@ pub fn nlopt_function_raw_callback<F: Func<T>, T>(
 pub fn nlopt_constraint_raw_callback<F: Func<T>, T>(
     n: libc::c_uint,
     x: *const f64,
-    g: *mut f64,
+    _g: *mut f64,
     params: *mut libc::c_void,
 ) -> f64 {
     let f = unsafe { &mut *(params as *mut NLoptConstraintCfg<F, T>) };
     let argument = unsafe { slice::from_raw_parts(x, n as usize) };
-    let gradient = if g.is_null() {
-        None
-    } else {
-        Some(unsafe { slice::from_raw_parts_mut(g, n as usize) })
-    };
-    (f.constraint_fn)(argument, gradient, &mut f.user_data)
+    // let gradient = if g.is_null() {
+    //     None
+    // } else {
+    //     Some(unsafe { slice::from_raw_parts_mut(g, n as usize) })
+    // };
+    // (f.constraint_fn)(argument, gradient, &mut f.user_data)
+    (f.constraint_fn)(argument, &mut f.user_data)
 }
 
 /// Packs an objective function with a user defined parameter set of type `T`.
@@ -73,17 +74,14 @@ pub struct NLoptConstraintCfg<F: Func<T>, T> {
     pub user_data: T,
 }
 
-/// A trait representing an objective function.
+/// A trait representing objective and constraints functions.
 ///
-/// An objective function takes the form of a closure `f(x: &[f64], gradient: Option<&mut [f64], user_data: &mut U) -> f64`
+/// An objective function takes the form of a closure `f(x: &[f64], user_data: &mut U) -> f64`
 ///
 /// * `x` - `n`-dimensional array
-/// * `gradient` - `n`-dimensional array to store the gradient `grad f(x)`. If `gradient` matches
-/// `Some(x)`, the user is required to provide a gradient, otherwise the optimization will
-/// probabely fail.
 /// * `user_data` - user defined data
-pub trait Func<U>: Fn(&[f64], Option<&mut [f64]>, &mut U) -> f64 {}
-impl<T, U> Func<U> for T where T: Fn(&[f64], Option<&mut [f64]>, &mut U) -> f64 {}
+pub trait Func<U>: Fn(&[f64], &mut U) -> f64 {}
+impl<T, U> Func<U> for T where T: Fn(&[f64], &mut U) -> f64 {}
 
 enum Io {
     stderr,
@@ -699,7 +697,7 @@ pub unsafe fn nlopt_eval_constraint<U>(
         //    ((*c).f).expect("non-null function pointer")(n, x, grad, (*c).f_data);
         // Maybe the U generic parameter required explains it cannot work like with C ???
         nlopt_constraint_raw_callback::<&dyn Func<U>, U>(n, x, grad, (*c).f_data);
-        // RLA: Take the opposite to manage cstr as being nonnegative in the end like the original cobyla
+        // relf: Take the opposite to manage cstr as being nonnegative in the end like the original cobyla
         *result.offset(0 as libc::c_int as isize) = -*result.offset(0 as libc::c_int as isize)
     } else {
         ((*c).mf).expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);


### PR DESCRIPTION
This PR is a total rework of the API, main points are:
* `fmin_cobyla` is removed  as `nlopt_cobyla` is more powerful (this cobyla version is still available through the argmin solver)
* `nlopt_cobyla` is renamed `minimize`, its arguments are made more Rusty