### PR TITLE
fix: Move function and constraint data into local allocations to avoid leaking the boxed data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,32 +195,37 @@ pub fn minimize<F: Func<U>, G: Func<U>, U: Clone>(
     rhobeg: RhoBeg,
     stop_tol: Option<StopTols>,
 ) -> Result<SuccessOutcome, FailOutcome> {
-    let fn_cfg = Box::new(NLoptFunctionCfg {
+    let fn_cfg = NLoptFunctionCfg {
         objective_fn: func,
         user_data: args.clone(),
-    });
-    let fn_cfg_ptr = Box::into_raw(fn_cfg) as *mut c_void;
+    };
+    // Take a pointer to the stack allocation.
+    let fn_cfg_ptr = &fn_cfg as *const _ as *mut c_void;
+
     let mut cstr_tol = 0.0; // no cstr tolerance
 
-    let mut cstr_cfg = cons
-        .iter()
-        .map(|c| {
-            let c_cfg = Box::new(NLoptConstraintCfg {
-                constraint_fn: c as &dyn Func<U>,
-                user_data: args.clone(),
-            });
-            let c_cfg_ptr = Box::into_raw(c_cfg) as *mut c_void;
-
-            nlopt_constraint {
-                m: 1,
-                f: Some(nlopt_constraint_raw_callback::<F, U>),
-                pre: None,
-                mf: None,
-                f_data: c_cfg_ptr,
-                tol: &mut cstr_tol,
-            }
-        })
-        .collect::<Vec<_>>();
+    // Allocate the data for the constraints.
+    let mut cstr_data = Vec::with_capacity(cons.len());
+    for c in cons {
+        cstr_data.push(NLoptConstraintCfg {
+            constraint_fn: c as &dyn Func<U>,
+            user_data: args.clone(),
+        });
+    }
+    // Allocate the constraint configs.
+    let mut cstr_cfg = Vec::with_capacity(cons.len());
+    for c in &cstr_data {
+        cstr_cfg.push(nlopt_constraint {
+            m: 1,
+            f: Some(nlopt_constraint_raw_callback::<F, U>),
+            pre: None,
+            mf: None,
+            // We can take a pointer to the constriant data as the
+            // vec is not modified after this point.
+            f_data: c as *const _ as *mut c_void,
+            tol: &mut cstr_tol,
+        });
+    }
 
     let mut x = vec![0.; xinit.len()];
     x.copy_from_slice(xinit);
@@ -308,12 +313,6 @@ pub fn minimize<F: Func<U>, G: Func<U>, U: Clone>(
             &mut stop,
             dx.as_mut_ptr(),
         )
-    };
-
-    // Convert the raw pointer back into a Box with the B::from_raw function,
-    // allowing the Box destructor to perform the cleanup.
-    unsafe {
-        let _ = Box::from_raw(fn_cfg_ptr as *mut NLoptFunctionCfg<F, U>);
     };
 
     match status {


### PR DESCRIPTION
Fixes the leaks (#26), and presumably performance improvement from not doing the additional allocations.

Same result with `cargo run --example paraboloid` as on main, though this is the only test case so hopefully I have not misunderstood the API here.