### PR TITLE
Refresh cobyla code from nlopt 2.10.1 using c2rust 0.22.1, remove libc dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [1.0.2-rc.1] - 2026-05-19
+
+* Regenerate nlopt_cobyla.rs code from nlopt 2.10.1 cobyla C code with [c2rust 0.22.1](https://github.com/immunant/c2rust).
+  Note: previous manual edits where re-introduced and libc dependency is removed
 
 ## [1.0.1] - 2026-05-18
 
@@ -53,7 +56,7 @@ COBYLA is now also implemented as an argmin::Solver to benefit from [argmin fram
 
 ## [0.2.0] - 2023-01-09
 
-COBYLA C code has been translated to Rust using [c2rust](https://github.com/immunant/c2rust) then manually edited.
+COBYLA C code has been translated to Rust using [c2rust 0.16](https://github.com/immunant/c2rust) then manually edited.
 
 ## [0.1.0] - 2022-05-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,5 @@ documentation = "https://docs.rs/cobyla"
 
 [features]
 
-[dependencies]
-libc = "0.2"
-
 [dev-dependencies]
 approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Remi Lafage <remi.lafage@onera.fr>"]
 name = "cobyla"
-version = "1.0.1"
+version = "1.0.2-rc.1"
 edition = "2024"
 license-file = "LICENSE.md"
 description = "COBYLA optimizer for Rust"

--- a/cobyla/nlopt/cobyla.rs
+++ b/cobyla/nlopt/cobyla.rs
@@ -1,50 +1,52 @@
 #![allow(
     dead_code,
-    mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
     unused_assignments,
     unused_mut
 )]
-#![register_tool(c2rust)]
-#![feature(c_variadic, extern_types, register_tool)]
+#![feature(c_variadic, extern_types, raw_ref_op)]
 extern "C" {
     pub type _IO_wide_data;
     pub type _IO_codecvt;
     pub type _IO_marker;
-    fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
-    fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    fn free(__ptr: *mut libc::c_void);
+    fn malloc(__size: size_t) -> *mut ::core::ffi::c_void;
+    fn realloc(__ptr: *mut ::core::ffi::c_void, __size: size_t) -> *mut ::core::ffi::c_void;
+    fn free(__ptr: *mut ::core::ffi::c_void);
     fn abort() -> !;
     static mut stderr: *mut FILE;
-    fn fprintf(_: *mut FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
+    fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::core::ffi::c_char,
+        ...
+    ) -> ::core::ffi::c_int;
     fn vsnprintf(
-        _: *mut libc::c_char,
-        _: libc::c_ulong,
-        _: *const libc::c_char,
-        _: ::std::ffi::VaList,
-    ) -> libc::c_int;
-    fn sqrt(_: libc::c_double) -> libc::c_double;
-    fn fabs(_: libc::c_double) -> libc::c_double;
-    fn gettimeofday(__tv: *mut timeval, __tz: *mut libc::c_void) -> libc::c_int;
-    fn strlen(_: *const libc::c_char) -> libc::c_ulong;
+        __s: *mut ::core::ffi::c_char,
+        __maxlen: size_t,
+        __format: *const ::core::ffi::c_char,
+        __arg: ::core::ffi::VaList,
+    ) -> ::core::ffi::c_int;
+    fn sqrt(__x: ::core::ffi::c_double) -> ::core::ffi::c_double;
+    fn fabs(__x: ::core::ffi::c_double) -> ::core::ffi::c_double;
+    fn gettimeofday(__tv: *mut timeval, __tz: __timezone_ptr_t) -> ::core::ffi::c_int;
+    fn strlen(__s: *const ::core::ffi::c_char) -> size_t;
 }
 pub type __builtin_va_list = [__va_list_tag; 1];
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
+    pub gp_offset: ::core::ffi::c_uint,
+    pub fp_offset: ::core::ffi::c_uint,
+    pub overflow_arg_area: *mut ::core::ffi::c_void,
+    pub reg_save_area: *mut ::core::ffi::c_void,
 }
-pub type size_t = libc::c_ulong;
-pub type __uint32_t = libc::c_uint;
-pub type __off_t = libc::c_long;
-pub type __off64_t = libc::c_long;
-pub type __time_t = libc::c_long;
-pub type __suseconds_t = libc::c_long;
+pub type size_t = usize;
+pub type __uint32_t = u32;
+pub type __off_t = ::core::ffi::c_long;
+pub type __off64_t = ::core::ffi::c_long;
+pub type __time_t = ::core::ffi::c_long;
+pub type __suseconds_t = ::core::ffi::c_long;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct timeval {
@@ -55,67 +57,66 @@ pub type va_list = __builtin_va_list;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct _IO_FILE {
-    pub _flags: libc::c_int,
-    pub _IO_read_ptr: *mut libc::c_char,
-    pub _IO_read_end: *mut libc::c_char,
-    pub _IO_read_base: *mut libc::c_char,
-    pub _IO_write_base: *mut libc::c_char,
-    pub _IO_write_ptr: *mut libc::c_char,
-    pub _IO_write_end: *mut libc::c_char,
-    pub _IO_buf_base: *mut libc::c_char,
-    pub _IO_buf_end: *mut libc::c_char,
-    pub _IO_save_base: *mut libc::c_char,
-    pub _IO_backup_base: *mut libc::c_char,
-    pub _IO_save_end: *mut libc::c_char,
+    pub _flags: ::core::ffi::c_int,
+    pub _IO_read_ptr: *mut ::core::ffi::c_char,
+    pub _IO_read_end: *mut ::core::ffi::c_char,
+    pub _IO_read_base: *mut ::core::ffi::c_char,
+    pub _IO_write_base: *mut ::core::ffi::c_char,
+    pub _IO_write_ptr: *mut ::core::ffi::c_char,
+    pub _IO_write_end: *mut ::core::ffi::c_char,
+    pub _IO_buf_base: *mut ::core::ffi::c_char,
+    pub _IO_buf_end: *mut ::core::ffi::c_char,
+    pub _IO_save_base: *mut ::core::ffi::c_char,
+    pub _IO_backup_base: *mut ::core::ffi::c_char,
+    pub _IO_save_end: *mut ::core::ffi::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
-    pub _fileno: libc::c_int,
-    pub _flags2: libc::c_int,
+    pub _fileno: ::core::ffi::c_int,
+    pub _flags2: ::core::ffi::c_int,
     pub _old_offset: __off_t,
-    pub _cur_column: libc::c_ushort,
-    pub _vtable_offset: libc::c_schar,
-    pub _shortbuf: [libc::c_char; 1],
-    pub _lock: *mut libc::c_void,
+    pub _cur_column: ::core::ffi::c_ushort,
+    pub _vtable_offset: ::core::ffi::c_schar,
+    pub _shortbuf: [::core::ffi::c_char; 1],
+    pub _lock: *mut ::core::ffi::c_void,
     pub _offset: __off64_t,
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
-    pub _freeres_buf: *mut libc::c_void,
+    pub _freeres_buf: *mut ::core::ffi::c_void,
     pub __pad5: size_t,
-    pub _mode: libc::c_int,
-    pub _unused2: [libc::c_char; 20],
+    pub _mode: ::core::ffi::c_int,
+    pub _unused2: [::core::ffi::c_char; 20],
 }
 pub type _IO_lock_t = ();
 pub type FILE = _IO_FILE;
-
 pub type nlopt_func = Option<
     unsafe extern "C" fn(
-        libc::c_uint,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
-    ) -> libc::c_double,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
+    ) -> ::core::ffi::c_double,
 >;
 pub type nlopt_mfunc = Option<
     unsafe extern "C" fn(
-        libc::c_uint,
-        *mut libc::c_double,
-        libc::c_uint,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
+        ::core::ffi::c_uint,
+        *mut ::core::ffi::c_double,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
     ) -> (),
 >;
 pub type nlopt_precond = Option<
     unsafe extern "C" fn(
-        libc::c_uint,
-        *const libc::c_double,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
     ) -> (),
 >;
-pub type nlopt_result = libc::c_int;
+pub type nlopt_result = ::core::ffi::c_int;
 pub const NLOPT_NUM_RESULTS: nlopt_result = 7;
 pub const NLOPT_MAXTIME_REACHED: nlopt_result = 6;
 pub const NLOPT_MAXEVAL_REACHED: nlopt_result = 5;
@@ -131,108 +132,89 @@ pub const NLOPT_INVALID_ARGS: nlopt_result = -2;
 pub const NLOPT_FAILURE: nlopt_result = -1;
 #[derive(Copy, Clone)]
 #[repr(C)]
+pub struct timezone {
+    pub tz_minuteswest: ::core::ffi::c_int,
+    pub tz_dsttime: ::core::ffi::c_int,
+}
+pub type __timezone_ptr_t = *mut timezone;
+#[derive(Copy, Clone)]
+#[repr(C)]
 pub struct nlopt_stopping {
-    pub n: libc::c_uint,
-    pub minf_max: libc::c_double,
-    pub ftol_rel: libc::c_double,
-    pub ftol_abs: libc::c_double,
-    pub xtol_rel: libc::c_double,
-    pub xtol_abs: *const libc::c_double,
-    pub x_weights: *const libc::c_double,
-    pub nevals_p: *mut libc::c_int,
-    pub maxeval: libc::c_int,
-    pub maxtime: libc::c_double,
-    pub start: libc::c_double,
-    pub force_stop: *mut libc::c_int,
-    pub stop_msg: *mut *mut libc::c_char,
+    pub n: ::core::ffi::c_uint,
+    pub minf_max: ::core::ffi::c_double,
+    pub ftol_rel: ::core::ffi::c_double,
+    pub ftol_abs: ::core::ffi::c_double,
+    pub xtol_rel: ::core::ffi::c_double,
+    pub xtol_abs: *const ::core::ffi::c_double,
+    pub x_weights: *const ::core::ffi::c_double,
+    pub nevals_p: *mut ::core::ffi::c_int,
+    pub maxeval: ::core::ffi::c_int,
+    pub maxtime: ::core::ffi::c_double,
+    pub start: ::core::ffi::c_double,
+    pub force_stop: *mut ::core::ffi::c_int,
+    pub stop_msg: *mut *mut ::core::ffi::c_char,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct nlopt_constraint {
-    pub m: libc::c_uint,
+    pub m: ::core::ffi::c_uint,
     pub f: nlopt_func,
     pub mf: nlopt_mfunc,
     pub pre: nlopt_precond,
-    pub f_data: *mut libc::c_void,
-    pub tol: *mut libc::c_double,
+    pub f_data: *mut ::core::ffi::c_void,
+    pub tol: *mut ::core::ffi::c_double,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct func_wrap_state {
     pub f: nlopt_func,
-    pub f_data: *mut libc::c_void,
-    pub m_orig: libc::c_uint,
+    pub f_data: *mut ::core::ffi::c_void,
+    pub m_orig: ::core::ffi::c_uint,
     pub fc: *mut nlopt_constraint,
-    pub p: libc::c_uint,
+    pub p: ::core::ffi::c_uint,
     pub h: *mut nlopt_constraint,
-    pub xtmp: *mut libc::c_double,
-    pub lb: *mut libc::c_double,
-    pub ub: *mut libc::c_double,
-    pub con_tol: *mut libc::c_double,
-    pub scale: *mut libc::c_double,
+    pub xtmp: *mut ::core::ffi::c_double,
+    pub lb: *mut ::core::ffi::c_double,
+    pub ub: *mut ::core::ffi::c_double,
+    pub con_tol: *mut ::core::ffi::c_double,
+    pub scale: *mut ::core::ffi::c_double,
     pub stop: *mut nlopt_stopping,
 }
 pub const COBYLA_MSG_NONE: C2RustUnnamed = 0;
 pub type cobyla_function = unsafe extern "C" fn(
-    libc::c_int,
-    libc::c_int,
-    *mut libc::c_double,
-    *mut libc::c_double,
-    *mut libc::c_double,
+    ::core::ffi::c_int,
+    ::core::ffi::c_int,
+    *mut ::core::ffi::c_double,
+    *mut ::core::ffi::c_double,
+    *mut ::core::ffi::c_double,
     *mut func_wrap_state,
-) -> libc::c_int;
+) -> ::core::ffi::c_int;
 pub type uint32_t = __uint32_t;
-pub type C2RustUnnamed = libc::c_uint;
+pub type C2RustUnnamed = ::core::ffi::c_uint;
 pub const COBYLA_MSG_INFO: C2RustUnnamed = 3;
 pub const COBYLA_MSG_ITER: C2RustUnnamed = 2;
 pub const COBYLA_MSG_EXIT: C2RustUnnamed = 1;
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_time_seed() -> libc::c_ulong {
-    let mut tv: timeval = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    gettimeofday(&mut tv, 0 as *mut libc::c_void);
-    return (tv.tv_sec ^ tv.tv_usec) as libc::c_ulong;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_seconds() -> libc::c_double {
-    static mut start_inited: libc::c_int = 0 as libc::c_int;
-    static mut start: timeval = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    let mut tv: timeval = timeval {
-        tv_sec: 0,
-        tv_usec: 0,
-    };
-    if start_inited == 0 {
-        start_inited = 1 as libc::c_int;
-        gettimeofday(&mut start, 0 as *mut libc::c_void);
-    }
-    gettimeofday(&mut tv, 0 as *mut libc::c_void);
-    return (tv.tv_sec - start.tv_sec) as libc::c_double
-        + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as libc::c_double;
-}
+pub const NULL: *mut ::core::ffi::c_void = ::core::ptr::null_mut::<::core::ffi::c_void>();
+pub const NULL_0: *mut ::core::ffi::c_void = ::core::ptr::null_mut::<::core::ffi::c_void>();
 unsafe extern "C" fn sc(
-    mut x: libc::c_double,
-    mut smin: libc::c_double,
-    mut smax: libc::c_double,
-) -> libc::c_double {
+    mut x: ::core::ffi::c_double,
+    mut smin: ::core::ffi::c_double,
+    mut smax: ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
     return smin + x * (smax - smin);
 }
 unsafe extern "C" fn vector_norm(
-    mut n: libc::c_uint,
-    mut vec: *const libc::c_double,
-    mut w: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_double {
-    let mut i: libc::c_uint = 0;
-    let mut ret: libc::c_double = 0 as libc::c_int as libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut vec: *const ::core::ffi::c_double,
+    mut w: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * fabs(sc(
@@ -243,7 +225,7 @@ unsafe extern "C" fn vector_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += fabs(sc(
                     *vec.offset(i as isize),
@@ -254,13 +236,13 @@ unsafe extern "C" fn vector_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * fabs(*vec.offset(i as isize));
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += fabs(*vec.offset(i as isize));
             i = i.wrapping_add(1);
@@ -269,18 +251,18 @@ unsafe extern "C" fn vector_norm(
     return ret;
 }
 unsafe extern "C" fn diff_norm(
-    mut n: libc::c_uint,
-    mut x: *const libc::c_double,
-    mut oldx: *const libc::c_double,
-    mut w: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_double {
-    let mut i: libc::c_uint = 0;
-    let mut ret: libc::c_double = 0 as libc::c_int as libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut x: *const ::core::ffi::c_double,
+    mut oldx: *const ::core::ffi::c_double,
+    mut w: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * fabs(
@@ -297,7 +279,7 @@ unsafe extern "C" fn diff_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += fabs(
                     sc(
@@ -314,13 +296,13 @@ unsafe extern "C" fn diff_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * fabs(*x.offset(i as isize) - *oldx.offset(i as isize));
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += fabs(*x.offset(i as isize) - *oldx.offset(i as isize));
             i = i.wrapping_add(1);
@@ -329,127 +311,128 @@ unsafe extern "C" fn diff_norm(
     return ret;
 }
 unsafe extern "C" fn relstop(
-    mut vold: libc::c_double,
-    mut vnew: libc::c_double,
-    mut reltol: libc::c_double,
-    mut abstol: libc::c_double,
-) -> libc::c_int {
+    mut vold: ::core::ffi::c_double,
+    mut vnew: ::core::ffi::c_double,
+    mut reltol: ::core::ffi::c_double,
+    mut abstol: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
     if nlopt_isinf(vold) != 0 {
-        return 0 as libc::c_int;
+        return 0 as ::core::ffi::c_int;
     }
     return (fabs(vnew - vold) < abstol
         || fabs(vnew - vold) < reltol * (fabs(vnew) + fabs(vold)) * 0.5f64
-        || reltol > 0 as libc::c_int as libc::c_double && vnew == vold) as libc::c_int;
+        || reltol > 0 as ::core::ffi::c_int as ::core::ffi::c_double && vnew == vold)
+        as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_ftol(
     mut s: *const nlopt_stopping,
-    mut f: libc::c_double,
-    mut oldf: libc::c_double,
-) -> libc::c_int {
+    mut f: ::core::ffi::c_double,
+    mut oldf: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
     return relstop(oldf, f, (*s).ftol_rel, (*s).ftol_abs);
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_f(
     mut s: *const nlopt_stopping,
-    mut f: libc::c_double,
-    mut oldf: libc::c_double,
-) -> libc::c_int {
-    return (f <= (*s).minf_max || nlopt_stop_ftol(s, f, oldf) != 0) as libc::c_int;
+    mut f: ::core::ffi::c_double,
+    mut oldf: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    return (f <= (*s).minf_max || nlopt_stop_ftol(s, f, oldf) != 0) as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_x(
     mut s: *const nlopt_stopping,
-    mut x: *const libc::c_double,
-    mut oldx: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut x: *const ::core::ffi::c_double,
+    mut oldx: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if diff_norm(
         (*s).n,
         x,
         oldx,
         (*s).x_weights,
-        0 as *const libc::c_double,
-        0 as *const libc::c_double,
+        ::core::ptr::null::<::core::ffi::c_double>(),
+        ::core::ptr::null::<::core::ffi::c_double>(),
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const libc::c_double,
-            0 as *const libc::c_double,
+            ::core::ptr::null::<::core::ffi::c_double>(),
+            ::core::ptr::null::<::core::ffi::c_double>(),
         )
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
-    if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+    if (*s).xtol_abs.is_null() {
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
         if fabs(*x.offset(i as isize) - *oldx.offset(i as isize))
-            >= *((*s).xtol_abs).offset(i as isize)
+            >= *(*s).xtol_abs.offset(i as isize)
         {
-            return 0 as libc::c_int;
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_dx(
     mut s: *const nlopt_stopping,
-    mut x: *const libc::c_double,
-    mut dx: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut x: *const ::core::ffi::c_double,
+    mut dx: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if vector_norm(
         (*s).n,
         dx,
         (*s).x_weights,
-        0 as *const libc::c_double,
-        0 as *const libc::c_double,
+        ::core::ptr::null::<::core::ffi::c_double>(),
+        ::core::ptr::null::<::core::ffi::c_double>(),
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const libc::c_double,
-            0 as *const libc::c_double,
+            ::core::ptr::null::<::core::ffi::c_double>(),
+            ::core::ptr::null::<::core::ffi::c_double>(),
         )
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
-    if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+    if (*s).xtol_abs.is_null() {
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
-        if fabs(*dx.offset(i as isize)) >= *((*s).xtol_abs).offset(i as isize) {
-            return 0 as libc::c_int;
+        if fabs(*dx.offset(i as isize)) >= *(*s).xtol_abs.offset(i as isize) {
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_xs(
     mut s: *const nlopt_stopping,
-    mut xs: *const libc::c_double,
-    mut oldxs: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut xs: *const ::core::ffi::c_double,
+    mut oldxs: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if diff_norm((*s).n, xs, oldxs, (*s).x_weights, scale_min, scale_max)
         < (*s).xtol_rel * vector_norm((*s).n, xs, (*s).x_weights, scale_min, scale_max)
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
-    if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+    if (*s).xtol_abs.is_null() {
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
         if fabs(
             sc(
@@ -461,117 +444,49 @@ pub unsafe extern "C" fn nlopt_stop_xs(
                 *scale_min.offset(i as isize),
                 *scale_max.offset(i as isize),
             ),
-        ) >= *((*s).xtol_abs).offset(i as isize)
+        ) >= *(*s).xtol_abs.offset(i as isize)
         {
-            return 0 as libc::c_int;
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 #[no_mangle]
-pub unsafe extern "C" fn nlopt_isinf(mut x: libc::c_double) -> libc::c_int {
-    return (fabs(x) >= ::std::f64::INFINITY * 0.99f64
-        || if x.is_infinite() {
-            if x.is_sign_positive() {
-                1
-            } else {
-                -1
-            }
-        } else {
-            0
-        } != 0) as libc::c_int;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_isfinite(mut x: libc::c_double) -> libc::c_int {
-    return (fabs(x) <= 1.7976931348623157e+308f64) as libc::c_int;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_istiny(mut x: libc::c_double) -> libc::c_int {
-    if x == 0.0f64 {
-        return 1 as libc::c_int;
-    } else {
-        return (fabs(x) < 2.2250738585072014e-308f64) as libc::c_int;
-    };
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_isnan(mut x: libc::c_double) -> libc::c_int {
-    return x.is_nan() as i32;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_stop_evals(mut s: *const nlopt_stopping) -> libc::c_int {
-    return ((*s).maxeval > 0 as libc::c_int && *(*s).nevals_p >= (*s).maxeval) as libc::c_int;
+pub unsafe extern "C" fn nlopt_stop_evals(mut s: *const nlopt_stopping) -> ::core::ffi::c_int {
+    return ((*s).maxeval > 0 as ::core::ffi::c_int && *(*s).nevals_p >= (*s).maxeval)
+        as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_stop_time_(
-    mut start: libc::c_double,
-    mut maxtime: libc::c_double,
-) -> libc::c_int {
-    return (maxtime > 0 as libc::c_int as libc::c_double && nlopt_seconds() - start >= maxtime)
-        as libc::c_int;
+    mut start: ::core::ffi::c_double,
+    mut maxtime: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    return (maxtime > 0 as ::core::ffi::c_int as ::core::ffi::c_double
+        && nlopt_seconds() - start >= maxtime) as ::core::ffi::c_int;
 }
 #[no_mangle]
-pub unsafe extern "C" fn nlopt_stop_time(mut s: *const nlopt_stopping) -> libc::c_int {
+pub unsafe extern "C" fn nlopt_stop_time(mut s: *const nlopt_stopping) -> ::core::ffi::c_int {
     return nlopt_stop_time_((*s).start, (*s).maxtime);
 }
 #[no_mangle]
-pub unsafe extern "C" fn nlopt_stop_evalstime(mut stop: *const nlopt_stopping) -> libc::c_int {
-    return (nlopt_stop_evals(stop) != 0 || nlopt_stop_time(stop) != 0) as libc::c_int;
+pub unsafe extern "C" fn nlopt_stop_evalstime(
+    mut stop: *const nlopt_stopping,
+) -> ::core::ffi::c_int {
+    return (nlopt_stop_evals(stop) != 0 || nlopt_stop_time(stop) != 0) as ::core::ffi::c_int;
 }
 #[no_mangle]
-pub unsafe extern "C" fn nlopt_stop_forced(mut stop: *const nlopt_stopping) -> libc::c_int {
-    return (!((*stop).force_stop).is_null() && *(*stop).force_stop != 0) as libc::c_int;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_vsprintf(
-    mut p: *mut libc::c_char,
-    mut format: *const libc::c_char,
-    mut ap: ::std::ffi::VaList,
-) -> *mut libc::c_char {
-    let mut len: size_t = (strlen(format)).wrapping_add(128 as libc::c_int as libc::c_ulong);
-    let mut ret: libc::c_int = 0;
-    p = realloc(p as *mut libc::c_void, len) as *mut libc::c_char;
-    if p.is_null() {
-        abort();
-    }
-    loop {
-        ret = vsnprintf(p, len, format, ap.as_va_list());
-        if !(ret < 0 as libc::c_int || ret as size_t >= len) {
-            break;
-        }
-        len = if ret >= 0 as libc::c_int {
-            (ret + 1 as libc::c_int) as size_t
-        } else {
-            len.wrapping_mul(3 as libc::c_int as libc::c_ulong) >> 1 as libc::c_int
-        };
-        p = realloc(p as *mut libc::c_void, len) as *mut libc::c_char;
-        if p.is_null() {
-            abort();
-        }
-    }
-    return p;
-}
-#[no_mangle]
-pub unsafe extern "C" fn nlopt_stop_msg(
-    mut s: *const nlopt_stopping,
-    mut format: *const libc::c_char,
-    mut args: ...
-) {
-    let mut ap: ::std::ffi::VaListImpl;
-    if !((*s).stop_msg).is_null() {
-        ap = args.clone();
-        let ref mut fresh0 = *(*s).stop_msg;
-        *fresh0 = nlopt_vsprintf(*(*s).stop_msg, format, ap.as_va_list());
-    }
+pub unsafe extern "C" fn nlopt_stop_forced(mut stop: *const nlopt_stopping) -> ::core::ffi::c_int {
+    return (!(*stop).force_stop.is_null() && *(*stop).force_stop != 0) as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_count_constraints(
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut c: *const nlopt_constraint,
-) -> libc::c_uint {
-    let mut i: libc::c_uint = 0;
-    let mut count: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    i = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_uint {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut count: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < p {
         count = count.wrapping_add((*c.offset(i as isize)).m);
         i = i.wrapping_add(1);
@@ -580,12 +495,12 @@ pub unsafe extern "C" fn nlopt_count_constraints(
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_max_constraint_dim(
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut c: *const nlopt_constraint,
-) -> libc::c_uint {
-    let mut i: libc::c_uint = 0;
-    let mut max_dim: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    i = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_uint {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut max_dim: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < p {
         if (*c.offset(i as isize)).m > max_dim {
             max_dim = (*c.offset(i as isize)).m;
@@ -596,54 +511,120 @@ pub unsafe extern "C" fn nlopt_max_constraint_dim(
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_eval_constraint(
-    mut result: *mut libc::c_double,
-    mut grad: *mut libc::c_double,
+    mut result: *mut ::core::ffi::c_double,
+    mut grad: *mut ::core::ffi::c_double,
     mut c: *const nlopt_constraint,
-    mut n: libc::c_uint,
-    mut x: *const libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut x: *const ::core::ffi::c_double,
 ) {
-    if ((*c).f).is_some() {
-        *result.offset(0 as libc::c_int as isize) =
-            ((*c).f).expect("non-null function pointer")(n, x, grad, (*c).f_data);
+    if (*c).f.is_some() {
+        *result.offset(0 as ::core::ffi::c_int as isize) =
+            (*c).f.expect("non-null function pointer")(n, x, grad, (*c).f_data);
     } else {
-        ((*c).mf).expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);
+        (*c).mf.expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);
     };
 }
 #[no_mangle]
-pub unsafe extern "C" fn nlopt_compute_rescaling(
-    mut n: libc::c_uint,
-    mut dx: *const libc::c_double,
-) -> *mut libc::c_double {
-    let mut s: *mut libc::c_double = malloc(
-        (::std::mem::size_of::<libc::c_double>() as libc::c_ulong).wrapping_mul(n as libc::c_ulong),
-    ) as *mut libc::c_double;
-
-    let mut vec: Vec<libc::c_double> = vec![0; usize::try_from(n).unwrap()];
-    let s = vec.as_mut_ptr() as *mut cobyla_context_t;
-
-    let mut i: libc::c_uint = 0;
-    if s.is_null() {
-        return 0 as *mut libc::c_double;
+pub unsafe extern "C" fn nlopt_vsprintf(
+    mut p: *mut ::core::ffi::c_char,
+    mut format: *const ::core::ffi::c_char,
+    mut ap: ::core::ffi::VaList,
+) -> *mut ::core::ffi::c_char {
+    let mut len: size_t = strlen(format).wrapping_add(128 as size_t);
+    let mut ret: ::core::ffi::c_int = 0;
+    p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
+    if p.is_null() {
+        abort();
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    loop {
+        ret = vsnprintf(p, len, format, ap.as_va_list());
+        if !(ret < 0 as ::core::ffi::c_int || ret as size_t >= len) {
+            break;
+        }
+        len = if ret >= 0 as ::core::ffi::c_int {
+            (ret + 1 as ::core::ffi::c_int) as size_t
+        } else {
+            len.wrapping_mul(3 as size_t) >> 1 as ::core::ffi::c_int
+        };
+        p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
+        if p.is_null() {
+            abort();
+        }
+    }
+    return p;
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_stop_msg(
+    mut s: *const nlopt_stopping,
+    mut format: *const ::core::ffi::c_char,
+    mut args: ...
+) {
+    let mut ap: ::core::ffi::VaListImpl;
+    if !(*s).stop_msg.is_null() {
+        ap = args.clone();
+        *(*s).stop_msg = nlopt_vsprintf(*(*s).stop_msg, format, ap.as_va_list());
+    }
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_isinf(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return (fabs(x) >= ::core::f64::INFINITY * 0.99f64
+        || if x.is_infinite() {
+            if x.is_sign_positive() {
+                1
+            } else {
+                -1
+            }
+        } else {
+            0
+        } != 0) as ::core::ffi::c_int;
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_isfinite(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return (fabs(x) <= DBL_MAX) as ::core::ffi::c_int;
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_istiny(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    if x == 0.0f64 {
+        return 1 as ::core::ffi::c_int;
+    } else {
+        return (fabs(x) < 2.2250738585072014e-308f64) as ::core::ffi::c_int;
+    };
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_isnan(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return x.is_nan() as i32;
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_compute_rescaling(
+    mut n: ::core::ffi::c_uint,
+    mut dx: *const ::core::ffi::c_double,
+) -> *mut ::core::ffi::c_double {
+    let mut s: *mut ::core::ffi::c_double = malloc(
+        (::core::mem::size_of::<::core::ffi::c_double>() as size_t).wrapping_mul(n as size_t),
+    ) as *mut ::core::ffi::c_double;
+    let mut i: ::core::ffi::c_uint = 0;
+    if s.is_null() {
+        return ::core::ptr::null_mut::<::core::ffi::c_double>();
+    }
+    i = 0 as ::core::ffi::c_uint;
     while i < n {
         *s.offset(i as isize) = 1.0f64;
         i = i.wrapping_add(1);
     }
-    if n == 1 as libc::c_int as libc::c_uint {
+    if n == 1 as ::core::ffi::c_uint {
         return s;
     }
-    i = 1 as libc::c_int as libc::c_uint;
+    i = 1 as ::core::ffi::c_uint;
     while i < n
-        && *dx.offset(i as isize)
-            == *dx.offset(i.wrapping_sub(1 as libc::c_int as libc::c_uint) as isize)
+        && *dx.offset(i as isize) == *dx.offset(i.wrapping_sub(1 as ::core::ffi::c_uint) as isize)
     {
         i = i.wrapping_add(1);
     }
     if i < n {
-        i = 1 as libc::c_int as libc::c_uint;
+        i = 1 as ::core::ffi::c_uint;
         while i < n {
-            *s.offset(i as isize) = *dx.offset(i as isize) / *dx.offset(0 as libc::c_int as isize);
+            *s.offset(i as isize) =
+                *dx.offset(i as isize) / *dx.offset(0 as ::core::ffi::c_int as isize);
             i = i.wrapping_add(1);
         }
     }
@@ -651,20 +632,20 @@ pub unsafe extern "C" fn nlopt_compute_rescaling(
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_rescale(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-    mut xs: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+    mut xs: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) / *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -673,20 +654,20 @@ pub unsafe extern "C" fn nlopt_rescale(
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_unscale(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-    mut xs: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+    mut xs: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) * *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -695,52 +676,80 @@ pub unsafe extern "C" fn nlopt_unscale(
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_new_rescaled(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-) -> *mut libc::c_double {
-    let mut xs: *mut libc::c_double = malloc(
-        (::std::mem::size_of::<libc::c_double>() as libc::c_ulong).wrapping_mul(n as libc::c_ulong),
-    ) as *mut libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+) -> *mut ::core::ffi::c_double {
+    let mut xs: *mut ::core::ffi::c_double = malloc(
+        (::core::mem::size_of::<::core::ffi::c_double>() as size_t).wrapping_mul(n as size_t),
+    ) as *mut ::core::ffi::c_double;
     if xs.is_null() {
-        return 0 as *mut libc::c_double;
+        return ::core::ptr::null_mut::<::core::ffi::c_double>();
     }
     nlopt_rescale(n, s, x, xs);
     return xs;
 }
 #[no_mangle]
 pub unsafe extern "C" fn nlopt_reorder_bounds(
-    mut n: libc::c_uint,
-    mut lb: *mut libc::c_double,
-    mut ub: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut lb: *mut ::core::ffi::c_double,
+    mut ub: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
-    i = 0 as libc::c_int as libc::c_uint;
+    let mut i: ::core::ffi::c_uint = 0;
+    i = 0 as ::core::ffi::c_uint;
     while i < n {
         if *lb.offset(i as isize) > *ub.offset(i as isize) {
-            let mut t: libc::c_double = *lb.offset(i as isize);
+            let mut t: ::core::ffi::c_double = *lb.offset(i as isize);
             *lb.offset(i as isize) = *ub.offset(i as isize);
             *ub.offset(i as isize) = t;
         }
         i = i.wrapping_add(1);
     }
 }
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_seconds() -> ::core::ffi::c_double {
+    static mut start_inited: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    static mut start: timeval = timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    let mut tv: timeval = timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    if start_inited == 0 {
+        start_inited = 1 as ::core::ffi::c_int;
+        gettimeofday(&raw mut start, ::core::ptr::null_mut::<timezone>());
+    }
+    gettimeofday(&raw mut tv, ::core::ptr::null_mut::<timezone>());
+    return (tv.tv_sec - start.tv_sec) as ::core::ffi::c_double
+        + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as ::core::ffi::c_double;
+}
+#[no_mangle]
+pub unsafe extern "C" fn nlopt_time_seed() -> ::core::ffi::c_ulong {
+    let mut tv: timeval = timeval {
+        tv_sec: 0,
+        tv_usec: 0,
+    };
+    gettimeofday(&raw mut tv, ::core::ptr::null_mut::<timezone>());
+    return (tv.tv_sec as __suseconds_t ^ tv.tv_usec) as ::core::ffi::c_ulong;
+}
 unsafe extern "C" fn func_wrap(
-    mut ni: libc::c_int,
-    mut mi: libc::c_int,
-    mut x: *mut libc::c_double,
-    mut f: *mut libc::c_double,
-    mut con: *mut libc::c_double,
+    mut ni: ::core::ffi::c_int,
+    mut mi: ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut f: *mut ::core::ffi::c_double,
+    mut con: *mut ::core::ffi::c_double,
     mut s: *mut func_wrap_state,
-) -> libc::c_int {
-    let mut n: libc::c_uint = ni as libc::c_uint;
-    let mut i: libc::c_uint = 0;
-    let mut j: libc::c_uint = 0;
-    let mut k: libc::c_uint = 0;
-    let mut xtmp: *mut libc::c_double = (*s).xtmp;
-    let mut lb: *const libc::c_double = (*s).lb;
-    let mut ub: *const libc::c_double = (*s).ub;
-    j = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_int {
+    let mut n: ::core::ffi::c_uint = ni as ::core::ffi::c_uint;
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut j: ::core::ffi::c_uint = 0;
+    let mut k: ::core::ffi::c_uint = 0;
+    let mut xtmp: *mut ::core::ffi::c_double = (*s).xtmp;
+    let mut lb: *const ::core::ffi::c_double = (*s).lb;
+    let mut ub: *const ::core::ffi::c_double = (*s).ub;
+    j = 0 as ::core::ffi::c_uint;
     while j < n {
         if *x.offset(j as isize) < *lb.offset(j as isize) {
             *xtmp.offset(j as isize) = *lb.offset(j as isize);
@@ -752,113 +761,111 @@ unsafe extern "C" fn func_wrap(
         j = j.wrapping_add(1);
     }
     nlopt_unscale(n, (*s).scale, xtmp, xtmp);
-    *f = ((*s).f).expect("non-null function pointer")(
+    *f = (*s).f.expect("non-null function pointer")(
         n,
         xtmp,
-        0 as *mut libc::c_double,
+        ::core::ptr::null_mut::<::core::ffi::c_double>(),
         (*s).f_data,
     );
     if nlopt_stop_forced((*s).stop) != 0 {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
-    j = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < (*s).m_orig {
         nlopt_eval_constraint(
             con.offset(i as isize),
-            0 as *mut libc::c_double,
-            ((*s).fc).offset(j as isize),
+            ::core::ptr::null_mut::<::core::ffi::c_double>(),
+            (*s).fc.offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
-            return 1 as libc::c_int;
+            return 1 as ::core::ffi::c_int;
         }
-        k = 0 as libc::c_int as libc::c_uint;
-        while k < (*((*s).fc).offset(j as isize)).m {
+        k = 0 as ::core::ffi::c_uint;
+        while k < (*(*s).fc.offset(j as isize)).m {
             *con.offset(i.wrapping_add(k) as isize) = -*con.offset(i.wrapping_add(k) as isize);
             k = k.wrapping_add(1);
         }
-        i = i.wrapping_add((*((*s).fc).offset(j as isize)).m);
+        i = i.wrapping_add((*(*s).fc.offset(j as isize)).m);
         j = j.wrapping_add(1);
     }
-    j = 0 as libc::c_int as libc::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < (*s).p {
         nlopt_eval_constraint(
             con.offset(i as isize),
-            0 as *mut libc::c_double,
-            ((*s).h).offset(j as isize),
+            ::core::ptr::null_mut::<::core::ffi::c_double>(),
+            (*s).h.offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
-            return 1 as libc::c_int;
+            return 1 as ::core::ffi::c_int;
         }
-        k = 0 as libc::c_int as libc::c_uint;
-        while k < (*((*s).h).offset(j as isize)).m {
+        k = 0 as ::core::ffi::c_uint;
+        while k < (*(*s).h.offset(j as isize)).m {
             *con.offset(
-                i.wrapping_add((*((*s).h).offset(j as isize)).m)
+                i.wrapping_add((*(*s).h.offset(j as isize)).m)
                     .wrapping_add(k) as isize,
             ) = -*con.offset(i.wrapping_add(k) as isize);
             k = k.wrapping_add(1);
         }
-        i = i.wrapping_add(
-            (2 as libc::c_int as libc::c_uint).wrapping_mul((*((*s).h).offset(j as isize)).m),
-        );
+        i = i.wrapping_add((2 as ::core::ffi::c_uint).wrapping_mul((*(*s).h.offset(j as isize)).m));
         j = j.wrapping_add(1);
     }
-    j = 0 as libc::c_int as libc::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < n {
         if nlopt_isinf(*lb.offset(j as isize)) == 0 {
-            let fresh1 = i;
+            let fresh0 = i;
             i = i.wrapping_add(1);
-            *con.offset(fresh1 as isize) = *x.offset(j as isize) - *lb.offset(j as isize);
+            *con.offset(fresh0 as isize) = *x.offset(j as isize) - *lb.offset(j as isize);
         }
         if nlopt_isinf(*ub.offset(j as isize)) == 0 {
-            let fresh2 = i;
+            let fresh1 = i;
             i = i.wrapping_add(1);
-            *con.offset(fresh2 as isize) = *ub.offset(j as isize) - *x.offset(j as isize);
+            *con.offset(fresh1 as isize) = *ub.offset(j as isize) - *x.offset(j as isize);
         }
         j = j.wrapping_add(1);
     }
-    return 0 as libc::c_int;
+    return 0 as ::core::ffi::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn cobyla_minimize(
-    mut n: libc::c_uint,
+    mut n: ::core::ffi::c_uint,
     mut f: nlopt_func,
-    mut f_data: *mut libc::c_void,
-    mut m: libc::c_uint,
+    mut f_data: *mut ::core::ffi::c_void,
+    mut m: ::core::ffi::c_uint,
     mut fc: *mut nlopt_constraint,
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut h: *mut nlopt_constraint,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut dx: *const libc::c_double,
+    mut dx: *const ::core::ffi::c_double,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut i: libc::c_uint = 0;
-    let mut j: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut j: ::core::ffi::c_uint = 0;
     let mut s: func_wrap_state = func_wrap_state {
         f: None,
-        f_data: 0 as *mut libc::c_void,
+        f_data: ::core::ptr::null_mut::<::core::ffi::c_void>(),
         m_orig: 0,
-        fc: 0 as *mut nlopt_constraint,
+        fc: ::core::ptr::null_mut::<nlopt_constraint>(),
         p: 0,
-        h: 0 as *mut nlopt_constraint,
-        xtmp: 0 as *mut libc::c_double,
-        lb: 0 as *mut libc::c_double,
-        ub: 0 as *mut libc::c_double,
-        con_tol: 0 as *mut libc::c_double,
-        scale: 0 as *mut libc::c_double,
-        stop: 0 as *mut nlopt_stopping,
+        h: ::core::ptr::null_mut::<nlopt_constraint>(),
+        xtmp: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        lb: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        ub: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        con_tol: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        scale: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        stop: ::core::ptr::null_mut::<nlopt_stopping>(),
     };
     let mut ret: nlopt_result = 0 as nlopt_result;
-    let mut rhobeg: libc::c_double = 0.;
-    let mut rhoend: libc::c_double = 0.;
+    let mut rhobeg: ::core::ffi::c_double = 0.;
+    let mut rhoend: ::core::ffi::c_double = 0.;
     s.f = f;
     s.f_data = f_data;
     s.m_orig = m;
@@ -866,80 +873,80 @@ pub unsafe extern "C" fn cobyla_minimize(
     s.p = p;
     s.h = h;
     s.stop = stop;
-    s.scale = 0 as *mut libc::c_double;
+    s.scale = ::core::ptr::null_mut::<::core::ffi::c_double>();
     s.con_tol = s.scale;
     s.xtmp = s.con_tol;
     s.ub = s.xtmp;
     s.lb = s.ub;
     s.scale = nlopt_compute_rescaling(n, dx);
-    if (s.scale).is_null() {
+    if s.scale.is_null() {
         ret = NLOPT_OUT_OF_MEMORY;
     } else {
-        j = 0 as libc::c_int as libc::c_uint;
+        j = 0 as ::core::ffi::c_uint;
         loop {
             if !(j < n) {
-                current_block = 15652330335145281839;
+                current_block = 12800627514080957624;
                 break;
             }
-            if *(s.scale).offset(j as isize) == 0 as libc::c_int as libc::c_double
-                || nlopt_isfinite(*(s.scale).offset(j as isize)) == 0
+            if *s.scale.offset(j as isize) == 0 as ::core::ffi::c_int as ::core::ffi::c_double
+                || nlopt_isfinite(*s.scale.offset(j as isize)) == 0
             {
                 nlopt_stop_msg(
                     stop,
                     b"invalid scaling %g of dimension %d: possible over/underflow?\0" as *const u8
-                        as *const libc::c_char,
-                    *(s.scale).offset(j as isize),
+                        as *const ::core::ffi::c_char,
+                    *s.scale.offset(j as isize),
                     j,
                 );
                 ret = NLOPT_INVALID_ARGS;
-                current_block = 762786280471819104;
+                current_block = 2538622867173152133;
                 break;
             } else {
                 j = j.wrapping_add(1);
             }
         }
         match current_block {
-            762786280471819104 => {}
+            2538622867173152133 => {}
             _ => {
                 s.lb = nlopt_new_rescaled(n, s.scale, lb);
-                if (s.lb).is_null() {
+                if s.lb.is_null() {
                     ret = NLOPT_OUT_OF_MEMORY;
                 } else {
                     s.ub = nlopt_new_rescaled(n, s.scale, ub);
-                    if (s.ub).is_null() {
+                    if s.ub.is_null() {
                         ret = NLOPT_OUT_OF_MEMORY;
                     } else {
                         nlopt_reorder_bounds(n, s.lb, s.ub);
                         s.xtmp = malloc(
-                            (::std::mem::size_of::<libc::c_double>() as libc::c_ulong)
-                                .wrapping_mul(n as libc::c_ulong),
-                        ) as *mut libc::c_double;
-                        if (s.xtmp).is_null() {
+                            (::core::mem::size_of::<::core::ffi::c_double>() as size_t)
+                                .wrapping_mul(n as size_t),
+                        ) as *mut ::core::ffi::c_double;
+                        if s.xtmp.is_null() {
                             ret = NLOPT_OUT_OF_MEMORY;
                         } else {
                             rhobeg = fabs(
-                                *dx.offset(0 as libc::c_int as isize)
-                                    / *(s.scale).offset(0 as libc::c_int as isize),
+                                *dx.offset(0 as ::core::ffi::c_int as isize)
+                                    / *s.scale.offset(0 as ::core::ffi::c_int as isize),
                             );
                             rhoend = (*stop).xtol_rel * rhobeg;
-                            if !((*stop).xtol_abs).is_null() {
-                                j = 0 as libc::c_int as libc::c_uint;
+                            if !(*stop).xtol_abs.is_null() {
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < n {
                                     if rhoend
-                                        < *((*stop).xtol_abs).offset(j as isize)
-                                            / fabs(*(s.scale).offset(j as isize))
+                                        < *(*stop).xtol_abs.offset(j as isize)
+                                            / fabs(*s.scale.offset(j as isize))
                                     {
-                                        rhoend = *((*stop).xtol_abs).offset(j as isize)
-                                            / fabs(*(s.scale).offset(j as isize));
+                                        rhoend = *(*stop).xtol_abs.offset(j as isize)
+                                            / fabs(*s.scale.offset(j as isize));
                                     }
                                     j = j.wrapping_add(1);
                                 }
                             }
-                            m = (nlopt_count_constraints(m, fc)).wrapping_add(
-                                (2 as libc::c_int as libc::c_uint)
+                            m = nlopt_count_constraints(m, fc).wrapping_add(
+                                (2 as ::core::ffi::c_uint)
                                     .wrapping_mul(nlopt_count_constraints(p, h)),
                             );
-                            j = 0 as libc::c_int as libc::c_uint;
+                            j = 0 as ::core::ffi::c_uint;
                             while j < n {
                                 if nlopt_isinf(*lb.offset(j as isize)) == 0 {
                                     m = m.wrapping_add(1);
@@ -950,57 +957,57 @@ pub unsafe extern "C" fn cobyla_minimize(
                                 j = j.wrapping_add(1);
                             }
                             s.con_tol = malloc(
-                                (::std::mem::size_of::<libc::c_double>() as libc::c_ulong)
-                                    .wrapping_mul(m as libc::c_ulong),
-                            ) as *mut libc::c_double;
-                            if m != 0 && (s.con_tol).is_null() {
+                                (::core::mem::size_of::<::core::ffi::c_double>() as size_t)
+                                    .wrapping_mul(m as size_t),
+                            ) as *mut ::core::ffi::c_double;
+                            if m != 0 && s.con_tol.is_null() {
                                 ret = NLOPT_OUT_OF_MEMORY;
                             } else {
-                                j = 0 as libc::c_int as libc::c_uint;
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < m {
-                                    *(s.con_tol).offset(j as isize) =
-                                        0 as libc::c_int as libc::c_double;
+                                    *s.con_tol.offset(j as isize) =
+                                        0 as ::core::ffi::c_int as ::core::ffi::c_double;
                                     j = j.wrapping_add(1);
                                 }
-                                i = 0 as libc::c_int as libc::c_uint;
+                                i = 0 as ::core::ffi::c_uint;
                                 j = i;
                                 while i < s.m_orig {
-                                    let mut ji: libc::c_uint = j;
-                                    let mut jnext: libc::c_uint =
+                                    let mut ji: ::core::ffi::c_uint = j;
+                                    let mut jnext: ::core::ffi::c_uint =
                                         j.wrapping_add((*fc.offset(i as isize)).m);
                                     while j < jnext {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*fc.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*fc.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     i = i.wrapping_add(1);
                                 }
-                                i = 0 as libc::c_int as libc::c_uint;
+                                i = 0 as ::core::ffi::c_uint;
                                 while i < s.p {
-                                    let mut ji_0: libc::c_uint = j;
-                                    let mut jnext_0: libc::c_uint =
+                                    let mut ji_0: ::core::ffi::c_uint = j;
+                                    let mut jnext_0: ::core::ffi::c_uint =
                                         j.wrapping_add((*h.offset(i as isize)).m);
                                     while j < jnext_0 {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*h.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji_0) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*h.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji_0) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     ji_0 = j;
                                     jnext_0 = j.wrapping_add((*h.offset(i as isize)).m);
                                     while j < jnext_0 {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*h.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji_0) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*h.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji_0) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     i = i.wrapping_add(1);
                                 }
                                 nlopt_rescale(n, s.scale, x, x);
                                 ret = cobyla(
-                                    n as libc::c_int,
-                                    m as libc::c_int,
+                                    n as ::core::ffi::c_int,
+                                    m as ::core::ffi::c_int,
                                     x,
                                     minf,
                                     rhobeg,
@@ -1008,23 +1015,23 @@ pub unsafe extern "C" fn cobyla_minimize(
                                     stop,
                                     s.lb,
                                     s.ub,
-                                    COBYLA_MSG_NONE as libc::c_int,
+                                    COBYLA_MSG_NONE as ::core::ffi::c_int,
                                     Some(
                                         func_wrap
                                             as unsafe extern "C" fn(
-                                                libc::c_int,
-                                                libc::c_int,
-                                                *mut libc::c_double,
-                                                *mut libc::c_double,
-                                                *mut libc::c_double,
+                                                ::core::ffi::c_int,
+                                                ::core::ffi::c_int,
+                                                *mut ::core::ffi::c_double,
+                                                *mut ::core::ffi::c_double,
+                                                *mut ::core::ffi::c_double,
                                                 *mut func_wrap_state,
                                             )
-                                                -> libc::c_int,
+                                                -> ::core::ffi::c_int,
                                     ),
-                                    &mut s,
+                                    &raw mut s,
                                 );
                                 nlopt_unscale(n, s.scale, x, x);
-                                j = 0 as libc::c_int as libc::c_uint;
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < n {
                                     if *x.offset(j as isize) < *lb.offset(j as isize) {
                                         *x.offset(j as isize) = *lb.offset(j as isize);
@@ -1041,102 +1048,104 @@ pub unsafe extern "C" fn cobyla_minimize(
             }
         }
     }
-    free(s.con_tol as *mut libc::c_void);
-    free(s.xtmp as *mut libc::c_void);
-    free(s.ub as *mut libc::c_void);
-    free(s.lb as *mut libc::c_void);
-    free(s.scale as *mut libc::c_void);
+    free(s.con_tol as *mut ::core::ffi::c_void);
+    free(s.xtmp as *mut ::core::ffi::c_void);
+    free(s.ub as *mut ::core::ffi::c_void);
+    free(s.lb as *mut ::core::ffi::c_void);
+    free(s.scale as *mut ::core::ffi::c_void);
     return ret;
 }
 unsafe extern "C" fn lcg_rand(mut seed: *mut uint32_t) -> uint32_t {
     *seed = (*seed)
-        .wrapping_mul(1103515245 as libc::c_int as libc::c_uint)
-        .wrapping_add(12345 as libc::c_int as libc::c_uint);
+        .wrapping_mul(1103515245 as uint32_t)
+        .wrapping_add(12345 as uint32_t);
     return *seed;
 }
 unsafe extern "C" fn lcg_urand(
     mut seed: *mut uint32_t,
-    mut a: libc::c_double,
-    mut b: libc::c_double,
-) -> libc::c_double {
-    return a + lcg_rand(seed) as libc::c_double * (b - a)
-        / -(1 as libc::c_int) as uint32_t as libc::c_double;
+    mut a: ::core::ffi::c_double,
+    mut b: ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    return a + lcg_rand(seed) as ::core::ffi::c_double * (b - a)
+        / -(1 as ::core::ffi::c_int) as uint32_t as ::core::ffi::c_double;
 }
 #[no_mangle]
 pub unsafe extern "C" fn cobyla(
-    mut n: libc::c_int,
-    mut m: libc::c_int,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
-    mut rhobeg: libc::c_double,
-    mut rhoend: libc::c_double,
+    mut n: ::core::ffi::c_int,
+    mut m: ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
+    mut rhobeg: ::core::ffi::c_double,
+    mut rhoend: ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut iprint: libc::c_int,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut iprint: ::core::ffi::c_int,
     mut calcfc: Option<cobyla_function>,
     mut state: *mut func_wrap_state,
 ) -> nlopt_result {
-    let mut icon: libc::c_int = 0;
-    let mut isim: libc::c_int = 0;
-    let mut isigb: libc::c_int = 0;
-    let mut idatm: libc::c_int = 0;
-    let mut iveta: libc::c_int = 0;
-    let mut isimi: libc::c_int = 0;
-    let mut ivsig: libc::c_int = 0;
-    let mut iwork: libc::c_int = 0;
-    let mut ia: libc::c_int = 0;
-    let mut idx: libc::c_int = 0;
-    let mut mpp: libc::c_int = 0;
-    let mut iact: *mut libc::c_int = 0 as *mut libc::c_int;
-    let mut w: *mut libc::c_double = 0 as *mut libc::c_double;
+    let mut icon: ::core::ffi::c_int = 0;
+    let mut isim: ::core::ffi::c_int = 0;
+    let mut isigb: ::core::ffi::c_int = 0;
+    let mut idatm: ::core::ffi::c_int = 0;
+    let mut iveta: ::core::ffi::c_int = 0;
+    let mut isimi: ::core::ffi::c_int = 0;
+    let mut ivsig: ::core::ffi::c_int = 0;
+    let mut iwork: ::core::ffi::c_int = 0;
+    let mut ia: ::core::ffi::c_int = 0;
+    let mut idx: ::core::ffi::c_int = 0;
+    let mut mpp: ::core::ffi::c_int = 0;
+    let mut iact: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
+    let mut w: *mut ::core::ffi::c_double = ::core::ptr::null_mut::<::core::ffi::c_double>();
     let mut rc: nlopt_result = 0 as nlopt_result;
-    *(*stop).nevals_p = 0 as libc::c_int;
-    if n == 0 as libc::c_int {
-        if iprint >= 1 as libc::c_int {
+    *(*stop).nevals_p = 0 as ::core::ffi::c_int;
+    if n == 0 as ::core::ffi::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(
                 stderr,
-                b"cobyla: N==0.\n\0" as *const u8 as *const libc::c_char,
+                b"cobyla: N==0.\n\0" as *const u8 as *const ::core::ffi::c_char,
             );
         }
         return NLOPT_SUCCESS;
     }
-    if n < 0 as libc::c_int || m < 0 as libc::c_int {
-        if iprint >= 1 as libc::c_int {
+    if n < 0 as ::core::ffi::c_int || m < 0 as ::core::ffi::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(
                 stderr,
-                b"cobyla: N<0 or M<0.\n\0" as *const u8 as *const libc::c_char,
+                b"cobyla: N<0 or M<0.\n\0" as *const u8 as *const ::core::ffi::c_char,
             );
         }
         return NLOPT_INVALID_ARGS;
     }
     w = malloc(
-        ((n * (3 as libc::c_int * n + 2 as libc::c_int * m + 11 as libc::c_int)
-            + 4 as libc::c_int * m
-            + 6 as libc::c_int) as libc::c_uint as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_double>() as libc::c_ulong),
-    ) as *mut libc::c_double;
+        ((n * (3 as ::core::ffi::c_int * n
+            + 2 as ::core::ffi::c_int * m
+            + 11 as ::core::ffi::c_int)
+            + 4 as ::core::ffi::c_int * m
+            + 6 as ::core::ffi::c_int) as ::core::ffi::c_uint as size_t)
+            .wrapping_mul(::core::mem::size_of::<::core::ffi::c_double>() as size_t),
+    ) as *mut ::core::ffi::c_double;
     if w.is_null() {
-        if iprint >= 1 as libc::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(
                 stderr,
-                b"cobyla: memory allocation error.\n\0" as *const u8 as *const libc::c_char,
+                b"cobyla: memory allocation error.\n\0" as *const u8 as *const ::core::ffi::c_char,
             );
         }
         return NLOPT_OUT_OF_MEMORY;
     }
     iact = malloc(
-        ((m + 1 as libc::c_int) as libc::c_uint as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_int>() as libc::c_ulong),
-    ) as *mut libc::c_int;
+        ((m + 1 as ::core::ffi::c_int) as ::core::ffi::c_uint as size_t)
+            .wrapping_mul(::core::mem::size_of::<::core::ffi::c_int>() as size_t),
+    ) as *mut ::core::ffi::c_int;
     if iact.is_null() {
-        if iprint >= 1 as libc::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(
                 stderr,
-                b"cobyla: memory allocation error.\n\0" as *const u8 as *const libc::c_char,
+                b"cobyla: memory allocation error.\n\0" as *const u8 as *const ::core::ffi::c_char,
             );
         }
-        free(w as *mut libc::c_void);
+        free(w as *mut ::core::ffi::c_void);
         return NLOPT_OUT_OF_MEMORY;
     }
     iact = iact.offset(-1);
@@ -1144,8 +1153,8 @@ pub unsafe extern "C" fn cobyla(
     x = x.offset(-1);
     lb = lb.offset(-1);
     ub = ub.offset(-1);
-    mpp = m + 2 as libc::c_int;
-    icon = 1 as libc::c_int;
+    mpp = m + 2 as ::core::ffi::c_int;
+    icon = 1 as ::core::ffi::c_int;
     isim = icon + mpp;
     isimi = isim + n * n + n;
     idatm = isimi + n * n;
@@ -1156,144 +1165,144 @@ pub unsafe extern "C" fn cobyla(
     idx = isigb + n;
     iwork = idx + n;
     rc = cobylb(
-        &mut n,
-        &mut m,
-        &mut mpp,
-        &mut *x.offset(1 as libc::c_int as isize),
+        &raw mut n,
+        &raw mut m,
+        &raw mut mpp,
+        x.offset(1 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_double,
         minf,
-        &mut rhobeg,
+        &raw mut rhobeg,
         rhoend,
         stop,
-        &*lb.offset(1 as libc::c_int as isize),
-        &*ub.offset(1 as libc::c_int as isize),
-        &mut iprint,
-        &mut *w.offset(icon as isize),
-        &mut *w.offset(isim as isize),
-        &mut *w.offset(isimi as isize),
-        &mut *w.offset(idatm as isize),
-        &mut *w.offset(ia as isize),
-        &mut *w.offset(ivsig as isize),
-        &mut *w.offset(iveta as isize),
-        &mut *w.offset(isigb as isize),
-        &mut *w.offset(idx as isize),
-        &mut *w.offset(iwork as isize),
-        &mut *iact.offset(1 as libc::c_int as isize),
+        lb.offset(1 as ::core::ffi::c_int as isize) as *const ::core::ffi::c_double,
+        ub.offset(1 as ::core::ffi::c_int as isize) as *const ::core::ffi::c_double,
+        &raw mut iprint,
+        w.offset(icon as isize) as *mut ::core::ffi::c_double,
+        w.offset(isim as isize) as *mut ::core::ffi::c_double,
+        w.offset(isimi as isize) as *mut ::core::ffi::c_double,
+        w.offset(idatm as isize) as *mut ::core::ffi::c_double,
+        w.offset(ia as isize) as *mut ::core::ffi::c_double,
+        w.offset(ivsig as isize) as *mut ::core::ffi::c_double,
+        w.offset(iveta as isize) as *mut ::core::ffi::c_double,
+        w.offset(isigb as isize) as *mut ::core::ffi::c_double,
+        w.offset(idx as isize) as *mut ::core::ffi::c_double,
+        w.offset(iwork as isize) as *mut ::core::ffi::c_double,
+        iact.offset(1 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_int,
         calcfc,
         state,
     );
     iact = iact.offset(1);
     w = w.offset(1);
-    free(w as *mut libc::c_void);
-    free(iact as *mut libc::c_void);
+    free(w as *mut ::core::ffi::c_void);
+    free(iact as *mut ::core::ffi::c_void);
     return rc;
 }
 unsafe extern "C" fn cobylb(
-    mut n: *mut libc::c_int,
-    mut m: *mut libc::c_int,
-    mut mpp: *mut libc::c_int,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
-    mut rhobeg: *mut libc::c_double,
-    mut rhoend: libc::c_double,
+    mut n: *mut ::core::ffi::c_int,
+    mut m: *mut ::core::ffi::c_int,
+    mut mpp: *mut ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
+    mut rhobeg: *mut ::core::ffi::c_double,
+    mut rhoend: ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut iprint: *mut libc::c_int,
-    mut con: *mut libc::c_double,
-    mut sim: *mut libc::c_double,
-    mut simi: *mut libc::c_double,
-    mut datmat: *mut libc::c_double,
-    mut a: *mut libc::c_double,
-    mut vsig: *mut libc::c_double,
-    mut veta: *mut libc::c_double,
-    mut sigbar: *mut libc::c_double,
-    mut dx: *mut libc::c_double,
-    mut w: *mut libc::c_double,
-    mut iact: *mut libc::c_int,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut iprint: *mut ::core::ffi::c_int,
+    mut con: *mut ::core::ffi::c_double,
+    mut sim: *mut ::core::ffi::c_double,
+    mut simi: *mut ::core::ffi::c_double,
+    mut datmat: *mut ::core::ffi::c_double,
+    mut a: *mut ::core::ffi::c_double,
+    mut vsig: *mut ::core::ffi::c_double,
+    mut veta: *mut ::core::ffi::c_double,
+    mut sigbar: *mut ::core::ffi::c_double,
+    mut dx: *mut ::core::ffi::c_double,
+    mut w: *mut ::core::ffi::c_double,
+    mut iact: *mut ::core::ffi::c_int,
     mut calcfc: Option<cobyla_function>,
     mut state: *mut func_wrap_state,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut sim_dim1: libc::c_int = 0;
-    let mut sim_offset: libc::c_int = 0;
-    let mut simi_dim1: libc::c_int = 0;
-    let mut simi_offset: libc::c_int = 0;
-    let mut datmat_dim1: libc::c_int = 0;
-    let mut datmat_offset: libc::c_int = 0;
-    let mut a_dim1: libc::c_int = 0;
-    let mut a_offset: libc::c_int = 0;
-    let mut i__1: libc::c_int = 0;
-    let mut i__2: libc::c_int = 0;
-    let mut i__3: libc::c_int = 0;
-    let mut d__1: libc::c_double = 0.;
-    let mut d__2: libc::c_double = 0.;
-    let mut alpha: libc::c_double = 0.;
-    let mut delta: libc::c_double = 0.;
-    let mut denom: libc::c_double = 0.;
-    let mut tempa: libc::c_double = 0.;
-    let mut barmu: libc::c_double = 0.;
-    let mut beta: libc::c_double = 0.;
-    let mut cmin: libc::c_double = 0.0f64;
-    let mut cmax: libc::c_double = 0.0f64;
-    let mut cvmaxm: libc::c_double = 0.;
-    let mut dxsign: libc::c_double = 0.;
-    let mut prerem: libc::c_double = 0.0f64;
-    let mut edgmax: libc::c_double = 0.;
-    let mut pareta: libc::c_double = 0.;
-    let mut prerec: libc::c_double = 0.0f64;
-    let mut phimin: libc::c_double = 0.;
-    let mut parsig: libc::c_double = 0.0f64;
-    let mut gamma_: libc::c_double = 0.;
-    let mut phi: libc::c_double = 0.;
-    let mut rho: libc::c_double = 0.;
-    let mut sum: libc::c_double = 0.0f64;
-    let mut ratio: libc::c_double = 0.;
-    let mut vmold: libc::c_double = 0.;
-    let mut parmu: libc::c_double = 0.;
-    let mut error: libc::c_double = 0.;
-    let mut vmnew: libc::c_double = 0.;
-    let mut resmax: libc::c_double = 0.;
-    let mut cvmaxp: libc::c_double = 0.;
-    let mut resnew: libc::c_double = 0.;
-    let mut trured: libc::c_double = 0.;
-    let mut temp: libc::c_double = 0.;
-    let mut wsig: libc::c_double = 0.;
-    let mut f: libc::c_double = 0.;
-    let mut weta: libc::c_double = 0.;
-    let mut i__: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut l: libc::c_int = 0;
-    let mut idxnew: libc::c_int = 0;
-    let mut iflag: libc::c_int = 0 as libc::c_int;
-    let mut iptemp: libc::c_int = 0;
-    let mut isdirn: libc::c_int = 0;
-    let mut izdota: libc::c_int = 0;
-    let mut ivmc: libc::c_int = 0;
-    let mut ivmd: libc::c_int = 0;
-    let mut mp: libc::c_int = 0;
-    let mut np: libc::c_int = 0;
-    let mut iz: libc::c_int = 0;
-    let mut ibrnch: libc::c_int = 0;
-    let mut nbest: libc::c_int = 0;
-    let mut ifull: libc::c_int = 0 as libc::c_int;
-    let mut iptem: libc::c_int = 0;
-    let mut jdrop: libc::c_int = 0;
+    let mut sim_dim1: ::core::ffi::c_int = 0;
+    let mut sim_offset: ::core::ffi::c_int = 0;
+    let mut simi_dim1: ::core::ffi::c_int = 0;
+    let mut simi_offset: ::core::ffi::c_int = 0;
+    let mut datmat_dim1: ::core::ffi::c_int = 0;
+    let mut datmat_offset: ::core::ffi::c_int = 0;
+    let mut a_dim1: ::core::ffi::c_int = 0;
+    let mut a_offset: ::core::ffi::c_int = 0;
+    let mut i__1: ::core::ffi::c_int = 0;
+    let mut i__2: ::core::ffi::c_int = 0;
+    let mut i__3: ::core::ffi::c_int = 0;
+    let mut d__1: ::core::ffi::c_double = 0.;
+    let mut d__2: ::core::ffi::c_double = 0.;
+    let mut alpha: ::core::ffi::c_double = 0.;
+    let mut delta: ::core::ffi::c_double = 0.;
+    let mut denom: ::core::ffi::c_double = 0.;
+    let mut tempa: ::core::ffi::c_double = 0.;
+    let mut barmu: ::core::ffi::c_double = 0.;
+    let mut beta: ::core::ffi::c_double = 0.;
+    let mut cmin: ::core::ffi::c_double = 0.0f64;
+    let mut cmax: ::core::ffi::c_double = 0.0f64;
+    let mut cvmaxm: ::core::ffi::c_double = 0.;
+    let mut dxsign: ::core::ffi::c_double = 0.;
+    let mut prerem: ::core::ffi::c_double = 0.0f64;
+    let mut edgmax: ::core::ffi::c_double = 0.;
+    let mut pareta: ::core::ffi::c_double = 0.;
+    let mut prerec: ::core::ffi::c_double = 0.0f64;
+    let mut phimin: ::core::ffi::c_double = 0.;
+    let mut parsig: ::core::ffi::c_double = 0.0f64;
+    let mut gamma_: ::core::ffi::c_double = 0.;
+    let mut phi: ::core::ffi::c_double = 0.;
+    let mut rho: ::core::ffi::c_double = 0.;
+    let mut sum: ::core::ffi::c_double = 0.0f64;
+    let mut ratio: ::core::ffi::c_double = 0.;
+    let mut vmold: ::core::ffi::c_double = 0.;
+    let mut parmu: ::core::ffi::c_double = 0.;
+    let mut error: ::core::ffi::c_double = 0.;
+    let mut vmnew: ::core::ffi::c_double = 0.;
+    let mut resmax: ::core::ffi::c_double = 0.;
+    let mut cvmaxp: ::core::ffi::c_double = 0.;
+    let mut resnew: ::core::ffi::c_double = 0.;
+    let mut trured: ::core::ffi::c_double = 0.;
+    let mut temp: ::core::ffi::c_double = 0.;
+    let mut wsig: ::core::ffi::c_double = 0.;
+    let mut f: ::core::ffi::c_double = 0.;
+    let mut weta: ::core::ffi::c_double = 0.;
+    let mut i__: ::core::ffi::c_int = 0;
+    let mut j: ::core::ffi::c_int = 0;
+    let mut k: ::core::ffi::c_int = 0;
+    let mut l: ::core::ffi::c_int = 0;
+    let mut idxnew: ::core::ffi::c_int = 0;
+    let mut iflag: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut iptemp: ::core::ffi::c_int = 0;
+    let mut isdirn: ::core::ffi::c_int = 0;
+    let mut izdota: ::core::ffi::c_int = 0;
+    let mut ivmc: ::core::ffi::c_int = 0;
+    let mut ivmd: ::core::ffi::c_int = 0;
+    let mut mp: ::core::ffi::c_int = 0;
+    let mut np: ::core::ffi::c_int = 0;
+    let mut iz: ::core::ffi::c_int = 0;
+    let mut ibrnch: ::core::ffi::c_int = 0;
+    let mut nbest: ::core::ffi::c_int = 0;
+    let mut ifull: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut iptem: ::core::ffi::c_int = 0;
+    let mut jdrop: ::core::ffi::c_int = 0;
     let mut rc: nlopt_result = NLOPT_SUCCESS;
     let mut seed: uint32_t = (*n + *m) as uint32_t;
-    let mut feasible: libc::c_int = 0;
-    *minf = ::std::f64::INFINITY;
+    let mut feasible: ::core::ffi::c_int = 0;
+    *minf = ::core::f64::INFINITY;
     a_dim1 = *n;
-    a_offset = 1 as libc::c_int + a_dim1 * 1 as libc::c_int;
+    a_offset = 1 as ::core::ffi::c_int + a_dim1 * 1 as ::core::ffi::c_int;
     a = a.offset(-(a_offset as isize));
     simi_dim1 = *n;
-    simi_offset = 1 as libc::c_int + simi_dim1 * 1 as libc::c_int;
+    simi_offset = 1 as ::core::ffi::c_int + simi_dim1 * 1 as ::core::ffi::c_int;
     simi = simi.offset(-(simi_offset as isize));
     sim_dim1 = *n;
-    sim_offset = 1 as libc::c_int + sim_dim1 * 1 as libc::c_int;
+    sim_offset = 1 as ::core::ffi::c_int + sim_dim1 * 1 as ::core::ffi::c_int;
     sim = sim.offset(-(sim_offset as isize));
     datmat_dim1 = *mpp;
-    datmat_offset = 1 as libc::c_int + datmat_dim1 * 1 as libc::c_int;
+    datmat_offset = 1 as ::core::ffi::c_int + datmat_dim1 * 1 as ::core::ffi::c_int;
     datmat = datmat.offset(-(datmat_offset as isize));
     x = x.offset(-1);
     con = con.offset(-1);
@@ -1305,36 +1314,36 @@ unsafe extern "C" fn cobylb(
     iact = iact.offset(-1);
     lb = lb.offset(-1);
     ub = ub.offset(-1);
-    iptem = if *n <= 4 as libc::c_int {
+    iptem = if *n <= 4 as ::core::ffi::c_int {
         *n
     } else {
-        4 as libc::c_int
+        4 as ::core::ffi::c_int
     };
-    iptemp = iptem + 1 as libc::c_int;
-    np = *n + 1 as libc::c_int;
-    mp = *m + 1 as libc::c_int;
+    iptemp = iptem + 1 as ::core::ffi::c_int;
+    np = *n + 1 as ::core::ffi::c_int;
+    mp = *m + 1 as ::core::ffi::c_int;
     alpha = 0.25f64;
     beta = 2.1f64;
     gamma_ = 0.5f64;
     delta = 1.1f64;
     rho = *rhobeg;
     parmu = 0.0f64;
-    if *iprint >= 2 as libc::c_int {
+    if *iprint >= 2 as ::core::ffi::c_int {
         fprintf(
             stderr,
             b"cobyla: the initial value of RHO is %12.6E and PARMU is set to zero.\n\0" as *const u8
-                as *const libc::c_char,
+                as *const ::core::ffi::c_char,
             rho,
         );
     }
     temp = 1.0f64 / rho;
     i__1 = *n;
-    i__ = 1 as libc::c_int;
+    i__ = 1 as ::core::ffi::c_int;
     while i__ <= i__1 {
-        let mut rhocur: libc::c_double = 0.;
+        let mut rhocur: ::core::ffi::c_double = 0.;
         *sim.offset((i__ + np * sim_dim1) as isize) = *x.offset(i__ as isize);
         i__2 = *n;
-        j = 1 as libc::c_int;
+        j = 1 as ::core::ffi::c_int;
         while j <= i__2 {
             *sim.offset((i__ + j * sim_dim1) as isize) = 0.0f64;
             *simi.offset((i__ + j * simi_dim1) as isize) = 0.0f64;
@@ -1357,82 +1366,90 @@ unsafe extern "C" fn cobylb(
         i__ += 1;
     }
     jdrop = np;
-    ibrnch = 0 as libc::c_int;
-    'c_6104: loop {
+    ibrnch = 0 as ::core::ffi::c_int;
+    '_L40: loop {
         if nlopt_stop_forced(stop) != 0 {
             rc = NLOPT_FORCED_STOP;
-        } else if *(*stop).nevals_p > 0 as libc::c_int {
+        } else if *(*stop).nevals_p > 0 as ::core::ffi::c_int {
             if nlopt_stop_evals(stop) != 0 {
                 rc = NLOPT_MAXEVAL_REACHED;
             } else if nlopt_stop_time(stop) != 0 {
                 rc = NLOPT_MAXTIME_REACHED;
             }
         }
-        if rc as libc::c_int != NLOPT_SUCCESS as libc::c_int {
-            current_block = 16949430136398296108;
+        if rc as ::core::ffi::c_int != NLOPT_SUCCESS as ::core::ffi::c_int {
+            current_block = 5794809869079527205;
             break;
         }
-        let ref mut fresh3 = *(*stop).nevals_p;
-        *fresh3 += 1;
+        *(*stop).nevals_p += 1;
         if calcfc.expect("non-null function pointer")(
             *n,
             *m,
-            &mut *x.offset(1 as libc::c_int as isize),
-            &mut f,
-            &mut *con.offset(1 as libc::c_int as isize),
+            x.offset(1 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_double,
+            &raw mut f,
+            con.offset(1 as ::core::ffi::c_int as isize) as *mut ::core::ffi::c_double,
             state,
         ) != 0
         {
-            if *iprint >= 1 as libc::c_int {
+            if *iprint >= 1 as ::core::ffi::c_int {
                 fprintf(
                     stderr,
                     b"cobyla: user requested end of minimization.\n\0" as *const u8
-                        as *const libc::c_char,
+                        as *const ::core::ffi::c_char,
                 );
             }
             rc = NLOPT_FORCED_STOP;
-            current_block = 16949430136398296108;
+            current_block = 5794809869079527205;
             break;
         } else {
             resmax = 0.0f64;
-            feasible = 1 as libc::c_int;
-            if *m > 0 as libc::c_int {
+            feasible = 1 as ::core::ffi::c_int;
+            if *m > 0 as ::core::ffi::c_int {
                 i__1 = *m;
-                k = 1 as libc::c_int;
+                k = 1 as ::core::ffi::c_int;
                 while k <= i__1 {
                     d__1 = resmax;
                     d__2 = -*con.offset(k as isize);
                     resmax = if d__1 >= d__2 { d__1 } else { d__2 };
-                    if d__2 > *((*state).con_tol).offset((k - 1 as libc::c_int) as isize) {
-                        feasible = 0 as libc::c_int;
+                    if d__2
+                        > *(*state)
+                            .con_tol
+                            .offset((k - 1 as ::core::ffi::c_int) as isize)
+                    {
+                        feasible = 0 as ::core::ffi::c_int;
                     }
                     k += 1;
                 }
             }
             if f < (*stop).minf_max && feasible != 0 {
                 rc = NLOPT_STOPVAL_REACHED;
-                current_block = 10710279849762345920;
+                current_block = 17687465368925105526;
                 break;
             } else {
-                if *(*stop).nevals_p == *iprint - 1 as libc::c_int || *iprint == 3 as libc::c_int {
+                if *(*stop).nevals_p == *iprint - 1 as ::core::ffi::c_int
+                    || *iprint == 3 as ::core::ffi::c_int
+                {
                     fprintf(
                         stderr,
                         b"cobyla: NFVALS = %4d, F =%13.6E, MAXCV =%13.6E\n\0" as *const u8
-                            as *const libc::c_char,
+                            as *const ::core::ffi::c_char,
                         *(*stop).nevals_p,
                         f,
                         resmax,
                     );
                     i__1 = iptem;
-                    fprintf(stderr, b"cobyla: X =\0" as *const u8 as *const libc::c_char);
-                    i__ = 1 as libc::c_int;
+                    fprintf(
+                        stderr,
+                        b"cobyla: X =\0" as *const u8 as *const ::core::ffi::c_char,
+                    );
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
-                        if i__ > 1 as libc::c_int {
-                            fprintf(stderr, b"  \0" as *const u8 as *const libc::c_char);
+                        if i__ > 1 as ::core::ffi::c_int {
+                            fprintf(stderr, b"  \0" as *const u8 as *const ::core::ffi::c_char);
                         }
                         fprintf(
                             stderr,
-                            b"%13.6E\0" as *const u8 as *const libc::c_char,
+                            b"%13.6E\0" as *const u8 as *const ::core::ffi::c_char,
                             *x.offset(i__ as isize),
                         );
                         i__ += 1;
@@ -1441,25 +1458,25 @@ unsafe extern "C" fn cobylb(
                         i__1 = *n;
                         i__ = iptemp;
                         while i__ <= i__1 {
-                            if (i__ - 1 as libc::c_int) % 4 as libc::c_int == 0 {
+                            if (i__ - 1 as ::core::ffi::c_int) % 4 as ::core::ffi::c_int == 0 {
                                 fprintf(
                                     stderr,
-                                    b"\ncobyla:  \0" as *const u8 as *const libc::c_char,
+                                    b"\ncobyla:  \0" as *const u8 as *const ::core::ffi::c_char,
                                 );
                             }
                             fprintf(
                                 stderr,
-                                b"%15.6E\0" as *const u8 as *const libc::c_char,
+                                b"%15.6E\0" as *const u8 as *const ::core::ffi::c_char,
                                 *x.offset(i__ as isize),
                             );
                             i__ += 1;
                         }
                     }
-                    fprintf(stderr, b"\n\0" as *const u8 as *const libc::c_char);
+                    fprintf(stderr, b"\n\0" as *const u8 as *const ::core::ffi::c_char);
                 }
                 *con.offset(mp as isize) = f;
                 *con.offset(*mpp as isize) = resmax;
-                if ibrnch == 1 as libc::c_int {
+                if ibrnch == 1 as ::core::ffi::c_int {
                     vmold = *datmat.offset((mp + np * datmat_dim1) as isize)
                         + parmu * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                     vmnew = f + parmu * resmax;
@@ -1469,16 +1486,16 @@ unsafe extern "C" fn cobylb(
                         trured = *datmat.offset((*mpp + np * datmat_dim1) as isize) - resmax;
                     }
                     ratio = 0.0f64;
-                    if trured <= 0.0f32 as libc::c_double {
-                        ratio = 1.0f32 as libc::c_double;
+                    if trured <= 0.0f64 {
+                        ratio = 1.0f64;
                     }
-                    jdrop = 0 as libc::c_int;
+                    jdrop = 0 as ::core::ffi::c_int;
                     i__1 = *n;
-                    j = 1 as libc::c_int;
+                    j = 1 as ::core::ffi::c_int;
                     while j <= i__1 {
                         temp = 0.0f64;
                         i__2 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__2 {
                             temp += *simi.offset((j + i__ * simi_dim1) as isize)
                                 * *dx.offset(i__ as isize);
@@ -1493,9 +1510,9 @@ unsafe extern "C" fn cobylb(
                         j += 1;
                     }
                     edgmax = delta * rho;
-                    l = 0 as libc::c_int;
+                    l = 0 as ::core::ffi::c_int;
                     i__1 = *n;
-                    j = 1 as libc::c_int;
+                    j = 1 as ::core::ffi::c_int;
                     while j <= i__1 {
                         if *sigbar.offset(j as isize) >= parsig
                             || *sigbar.offset(j as isize) >= *vsig.offset(j as isize)
@@ -1504,7 +1521,7 @@ unsafe extern "C" fn cobylb(
                             if trured > 0.0f64 {
                                 temp = 0.0f64;
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     d__1 = *dx.offset(i__ as isize)
                                         - *sim.offset((i__ + j * sim_dim1) as isize);
@@ -1520,15 +1537,15 @@ unsafe extern "C" fn cobylb(
                         }
                         j += 1;
                     }
-                    if l > 0 as libc::c_int {
+                    if l > 0 as ::core::ffi::c_int {
                         jdrop = l;
                     }
-                    if jdrop == 0 as libc::c_int {
-                        current_block = 17974563553836679504;
+                    if jdrop == 0 as ::core::ffi::c_int {
+                        current_block = 17164062518686415970;
                     } else {
                         temp = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *sim.offset((i__ + jdrop * sim_dim1) as isize) =
                                 *dx.offset(i__ as isize);
@@ -1537,25 +1554,25 @@ unsafe extern "C" fn cobylb(
                             i__ += 1;
                         }
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *simi.offset((jdrop + i__ * simi_dim1) as isize) /= temp;
                             i__ += 1;
                         }
                         i__1 = *n;
-                        j = 1 as libc::c_int;
+                        j = 1 as ::core::ffi::c_int;
                         while j <= i__1 {
                             if j != jdrop {
                                 temp = 0.0f64;
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     temp += *simi.offset((j + i__ * simi_dim1) as isize)
                                         * *dx.offset(i__ as isize);
                                     i__ += 1;
                                 }
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     *simi.offset((j + i__ * simi_dim1) as isize) -=
                                         temp * *simi.offset((jdrop + i__ * simi_dim1) as isize);
@@ -1565,7 +1582,7 @@ unsafe extern "C" fn cobylb(
                             j += 1;
                         }
                         i__1 = *mpp;
-                        k = 1 as libc::c_int;
+                        k = 1 as ::core::ffi::c_int;
                         while k <= i__1 {
                             *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                                 *con.offset(k as isize);
@@ -1576,14 +1593,14 @@ unsafe extern "C" fn cobylb(
                             {
                                 rho *= 2.0f64;
                             }
-                            current_block = 16207618807156029286;
+                            current_block = 9835236904106541358;
                         } else {
-                            current_block = 17974563553836679504;
+                            current_block = 17164062518686415970;
                         }
                     }
                 } else {
                     i__1 = *mpp;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                             *con.offset(k as isize);
@@ -1595,12 +1612,12 @@ unsafe extern "C" fn cobylb(
                                 *x.offset(jdrop as isize) =
                                     *sim.offset((jdrop + np * sim_dim1) as isize);
                             } else {
-                                let mut rhocur_0: libc::c_double = *x.offset(jdrop as isize)
+                                let mut rhocur_0: ::core::ffi::c_double = *x.offset(jdrop as isize)
                                     - *sim.offset((jdrop + np * sim_dim1) as isize);
                                 *sim.offset((jdrop + np * sim_dim1) as isize) =
                                     *x.offset(jdrop as isize);
                                 i__1 = *mpp;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__1 {
                                     *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                                         *datmat.offset((k + np * datmat_dim1) as isize);
@@ -1609,10 +1626,10 @@ unsafe extern "C" fn cobylb(
                                     k += 1;
                                 }
                                 i__1 = jdrop;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__1 {
                                     *sim.offset((jdrop + k * sim_dim1) as isize) = -rhocur_0;
-                                    temp = 0.0f32 as libc::c_double;
+                                    temp = 0.0f64;
                                     i__2 = jdrop;
                                     i__ = k;
                                     while i__ <= i__2 {
@@ -1631,25 +1648,26 @@ unsafe extern "C" fn cobylb(
                             continue;
                         }
                     }
-                    ibrnch = 1 as libc::c_int;
-                    current_block = 16207618807156029286;
+                    ibrnch = 1 as ::core::ffi::c_int;
+                    current_block = 9835236904106541358;
                 }
-                'c_6122: loop {
+                '_L140: loop {
                     match current_block {
-                        17974563553836679504 => {
-                            if iflag == 0 as libc::c_int {
-                                ibrnch = 0 as libc::c_int;
-                                current_block = 16207618807156029286;
+                        17164062518686415970 => {
+                            if iflag == 0 as ::core::ffi::c_int {
+                                ibrnch = 0 as ::core::ffi::c_int;
+                                current_block = 9835236904106541358;
                             } else {
-                                let mut fbest: libc::c_double = if ifull == 1 as libc::c_int {
-                                    f
-                                } else {
-                                    *datmat.offset((mp + np * datmat_dim1) as isize)
-                                };
+                                let mut fbest: ::core::ffi::c_double =
+                                    if ifull == 1 as ::core::ffi::c_int {
+                                        f
+                                    } else {
+                                        *datmat.offset((mp + np * datmat_dim1) as isize)
+                                    };
                                 if fbest < *minf && nlopt_stop_ftol(stop, fbest, *minf) != 0 {
                                     rc = NLOPT_FTOL_REACHED;
-                                    current_block = 16949430136398296108;
-                                    break 'c_6104;
+                                    current_block = 5794809869079527205;
+                                    break '_L40;
                                 } else {
                                     *minf = fbest;
                                     if rho > rhoend {
@@ -1660,13 +1678,13 @@ unsafe extern "C" fn cobylb(
                                         if parmu > 0.0f64 {
                                             denom = 0.0f64;
                                             i__1 = mp;
-                                            k = 1 as libc::c_int;
+                                            k = 1 as ::core::ffi::c_int;
                                             while k <= i__1 {
                                                 cmin =
                                                     *datmat.offset((k + np * datmat_dim1) as isize);
                                                 cmax = cmin;
                                                 i__2 = *n;
-                                                i__ = 1 as libc::c_int;
+                                                i__ = 1 as ::core::ffi::c_int;
                                                 while i__ <= i__2 {
                                                     d__1 = cmin;
                                                     d__2 = *datmat
@@ -1702,20 +1720,20 @@ unsafe extern "C" fn cobylb(
                                                 parmu = (cmax - cmin) / denom;
                                             }
                                         }
-                                        if *iprint >= 2 as libc::c_int {
+                                        if *iprint >= 2 as ::core::ffi::c_int {
                                             fprintf(
                                                 stderr,
                                                 b"cobyla: reduction in RHO to %12.6E and PARMU =%13.6E\n\0"
-                                                    as *const u8 as *const libc::c_char,
+                                                    as *const u8 as *const ::core::ffi::c_char,
                                                 rho,
                                                 parmu,
                                             );
                                         }
-                                        if *iprint == 2 as libc::c_int {
+                                        if *iprint == 2 as ::core::ffi::c_int {
                                             fprintf(
                                                 stderr,
                                                 b"cobyla: NFVALS = %4d, F =%13.6E, MAXCV =%13.6E\n\0"
-                                                    as *const u8 as *const libc::c_char,
+                                                    as *const u8 as *const ::core::ffi::c_char,
                                                 *(*stop).nevals_p,
                                                 *datmat.offset((mp + np * datmat_dim1) as isize),
                                                 *datmat.offset((*mpp + np * datmat_dim1) as isize),
@@ -1723,20 +1741,22 @@ unsafe extern "C" fn cobylb(
                                             fprintf(
                                                 stderr,
                                                 b"cobyla: X =\0" as *const u8
-                                                    as *const libc::c_char,
+                                                    as *const ::core::ffi::c_char,
                                             );
                                             i__1 = iptem;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__1 {
-                                                if i__ > 1 as libc::c_int {
+                                                if i__ > 1 as ::core::ffi::c_int {
                                                     fprintf(
                                                         stderr,
-                                                        b"  \0" as *const u8 as *const libc::c_char,
+                                                        b"  \0" as *const u8
+                                                            as *const ::core::ffi::c_char,
                                                     );
                                                 }
                                                 fprintf(
                                                     stderr,
-                                                    b"%13.6E\0" as *const u8 as *const libc::c_char,
+                                                    b"%13.6E\0" as *const u8
+                                                        as *const ::core::ffi::c_char,
                                                     *sim.offset((i__ + np * sim_dim1) as isize),
                                                 );
                                                 i__ += 1;
@@ -1745,19 +1765,20 @@ unsafe extern "C" fn cobylb(
                                                 i__1 = *n;
                                                 i__ = iptemp;
                                                 while i__ <= i__1 {
-                                                    if (i__ - 1 as libc::c_int) % 4 as libc::c_int
+                                                    if (i__ - 1 as ::core::ffi::c_int)
+                                                        % 4 as ::core::ffi::c_int
                                                         == 0
                                                     {
                                                         fprintf(
                                                             stderr,
                                                             b"\ncobyla:  \0" as *const u8
-                                                                as *const libc::c_char,
+                                                                as *const ::core::ffi::c_char,
                                                         );
                                                     }
                                                     fprintf(
                                                         stderr,
                                                         b"%15.6E\0" as *const u8
-                                                            as *const libc::c_char,
+                                                            as *const ::core::ffi::c_char,
                                                         *x.offset(i__ as isize),
                                                     );
                                                     i__ += 1;
@@ -1765,30 +1786,32 @@ unsafe extern "C" fn cobylb(
                                             }
                                             fprintf(
                                                 stderr,
-                                                b"\n\0" as *const u8 as *const libc::c_char,
+                                                b"\n\0" as *const u8 as *const ::core::ffi::c_char,
                                             );
                                         }
-                                        current_block = 16207618807156029286;
+                                        current_block = 9835236904106541358;
                                     } else {
-                                        rc = (if rhoend > 0 as libc::c_int as libc::c_double {
-                                            NLOPT_XTOL_REACHED as libc::c_int
+                                        rc = (if rhoend
+                                            > 0 as ::core::ffi::c_int as ::core::ffi::c_double
+                                        {
+                                            NLOPT_XTOL_REACHED as ::core::ffi::c_int
                                         } else {
-                                            NLOPT_ROUNDOFF_LIMITED as libc::c_int
+                                            NLOPT_ROUNDOFF_LIMITED as ::core::ffi::c_int
                                         })
                                             as nlopt_result;
-                                        if *iprint >= 1 as libc::c_int {
+                                        if *iprint >= 1 as ::core::ffi::c_int {
                                             fprintf(
                                                 stderr,
                                                 b"cobyla: normal return.\n\0" as *const u8
-                                                    as *const libc::c_char,
+                                                    as *const ::core::ffi::c_char,
                                             );
                                         }
-                                        if ifull == 1 as libc::c_int {
-                                            current_block = 10710279849762345920;
-                                            break 'c_6104;
+                                        if ifull == 1 as ::core::ffi::c_int {
+                                            current_block = 17687465368925105526;
+                                            break '_L40;
                                         } else {
-                                            current_block = 16949430136398296108;
-                                            break 'c_6104;
+                                            current_block = 5794809869079527205;
+                                            break '_L40;
                                         }
                                     }
                                 }
@@ -1799,7 +1822,7 @@ unsafe extern "C" fn cobylb(
                                 + parmu * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                             nbest = np;
                             i__1 = *n;
-                            j = 1 as libc::c_int;
+                            j = 1 as ::core::ffi::c_int;
                             while j <= i__1 {
                                 temp = *datmat.offset((mp + j * datmat_dim1) as isize)
                                     + parmu * *datmat.offset((*mpp + j * datmat_dim1) as isize);
@@ -1817,7 +1840,7 @@ unsafe extern "C" fn cobylb(
                             }
                             if nbest <= *n {
                                 i__1 = *mpp;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *datmat.offset((i__ + np * datmat_dim1) as isize);
                                     *datmat.offset((i__ + np * datmat_dim1) as isize) =
@@ -1826,14 +1849,14 @@ unsafe extern "C" fn cobylb(
                                     i__ += 1;
                                 }
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *sim.offset((i__ + nbest * sim_dim1) as isize);
                                     *sim.offset((i__ + nbest * sim_dim1) as isize) = 0.0f64;
                                     *sim.offset((i__ + np * sim_dim1) as isize) += temp;
                                     tempa = 0.0f64;
                                     i__2 = *n;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__2 {
                                         *sim.offset((i__ + k * sim_dim1) as isize) -= temp;
                                         tempa -= *simi.offset((k + i__ * simi_dim1) as isize);
@@ -1845,20 +1868,20 @@ unsafe extern "C" fn cobylb(
                             }
                             error = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 i__2 = *n;
-                                j = 1 as libc::c_int;
+                                j = 1 as ::core::ffi::c_int;
                                 while j <= i__2 {
                                     temp = 0.0f64;
                                     if i__ == j {
                                         temp += -1.0f64;
                                     }
                                     i__3 = *n;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__3 {
                                         if *sim.offset((k + j * sim_dim1) as isize)
-                                            != 0 as libc::c_int as libc::c_double
+                                            != 0 as ::core::ffi::c_int as ::core::ffi::c_double
                                         {
                                             temp += *simi.offset((i__ + k * simi_dim1) as isize)
                                                 * *sim.offset((k + j * sim_dim1) as isize);
@@ -1873,25 +1896,25 @@ unsafe extern "C" fn cobylb(
                                 i__ += 1;
                             }
                             if error > 0.1f64 {
-                                if *iprint >= 1 as libc::c_int {
+                                if *iprint >= 1 as ::core::ffi::c_int {
                                     fprintf(
                                         stderr,
                                         b"cobyla: rounding errors are becoming damaging.\n\0"
                                             as *const u8
-                                            as *const libc::c_char,
+                                            as *const ::core::ffi::c_char,
                                     );
                                 }
                                 rc = NLOPT_ROUNDOFF_LIMITED;
-                                current_block = 16949430136398296108;
-                                break 'c_6104;
+                                current_block = 5794809869079527205;
+                                break '_L40;
                             } else {
                                 i__2 = mp;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__2 {
                                     *con.offset(k as isize) =
                                         -*datmat.offset((k + np * datmat_dim1) as isize);
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         *w.offset(j as isize) = *datmat
                                             .offset((k + j * datmat_dim1) as isize)
@@ -1899,11 +1922,11 @@ unsafe extern "C" fn cobylb(
                                         j += 1;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         temp = 0.0f64;
                                         i__3 = *n;
-                                        j = 1 as libc::c_int;
+                                        j = 1 as ::core::ffi::c_int;
                                         while j <= i__3 {
                                             temp += *w.offset(j as isize)
                                                 * *simi.offset((j + i__ * simi_dim1) as isize);
@@ -1917,16 +1940,16 @@ unsafe extern "C" fn cobylb(
                                     }
                                     k += 1;
                                 }
-                                iflag = 1 as libc::c_int;
+                                iflag = 1 as ::core::ffi::c_int;
                                 parsig = alpha * rho;
                                 pareta = beta * rho;
                                 i__1 = *n;
-                                j = 1 as libc::c_int;
+                                j = 1 as ::core::ffi::c_int;
                                 while j <= i__1 {
                                     wsig = 0.0f64;
                                     weta = 0.0f64;
                                     i__2 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__2 {
                                         d__1 = *simi.offset((j + i__ * simi_dim1) as isize);
                                         wsig += d__1 * d__1;
@@ -1939,12 +1962,14 @@ unsafe extern "C" fn cobylb(
                                     if *vsig.offset(j as isize) < parsig
                                         || *veta.offset(j as isize) > pareta
                                     {
-                                        iflag = 0 as libc::c_int;
+                                        iflag = 0 as ::core::ffi::c_int;
                                     }
                                     j += 1;
                                 }
-                                if ibrnch == 1 as libc::c_int || iflag == 1 as libc::c_int {
-                                    iz = 1 as libc::c_int;
+                                if ibrnch == 1 as ::core::ffi::c_int
+                                    || iflag == 1 as ::core::ffi::c_int
+                                {
+                                    iz = 1 as ::core::ffi::c_int;
                                     izdota = iz + *n * *n;
                                     ivmc = izdota + *n;
                                     isdirn = ivmc + mp;
@@ -1953,27 +1978,32 @@ unsafe extern "C" fn cobylb(
                                     rc = trstlp(
                                         n,
                                         m,
-                                        &mut *a.offset(a_offset as isize),
-                                        &mut *con.offset(1 as libc::c_int as isize),
-                                        &mut rho,
-                                        &mut *dx.offset(1 as libc::c_int as isize),
-                                        &mut ifull,
-                                        &mut *iact.offset(1 as libc::c_int as isize),
-                                        &mut *w.offset(iz as isize),
-                                        &mut *w.offset(izdota as isize),
-                                        &mut *w.offset(ivmc as isize),
-                                        &mut *w.offset(isdirn as isize),
-                                        &mut *w.offset(idxnew as isize),
-                                        &mut *w.offset(ivmd as isize),
+                                        a.offset(a_offset as isize) as *mut ::core::ffi::c_double,
+                                        con.offset(1 as ::core::ffi::c_int as isize)
+                                            as *mut ::core::ffi::c_double,
+                                        &raw mut rho,
+                                        dx.offset(1 as ::core::ffi::c_int as isize)
+                                            as *mut ::core::ffi::c_double,
+                                        &raw mut ifull,
+                                        iact.offset(1 as ::core::ffi::c_int as isize)
+                                            as *mut ::core::ffi::c_int,
+                                        w.offset(iz as isize) as *mut ::core::ffi::c_double,
+                                        w.offset(izdota as isize) as *mut ::core::ffi::c_double,
+                                        w.offset(ivmc as isize) as *mut ::core::ffi::c_double,
+                                        w.offset(isdirn as isize) as *mut ::core::ffi::c_double,
+                                        w.offset(idxnew as isize) as *mut ::core::ffi::c_double,
+                                        w.offset(ivmd as isize) as *mut ::core::ffi::c_double,
                                     );
-                                    if rc as libc::c_int != NLOPT_SUCCESS as libc::c_int {
-                                        current_block = 16949430136398296108;
-                                        break 'c_6104;
+                                    if rc as ::core::ffi::c_int
+                                        != NLOPT_SUCCESS as ::core::ffi::c_int
+                                    {
+                                        current_block = 5794809869079527205;
+                                        break '_L40;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
-                                        let mut xi_0: libc::c_double =
+                                        let mut xi_0: ::core::ffi::c_double =
                                             *sim.offset((i__ + np * sim_dim1) as isize);
                                         if xi_0 + *dx.offset(i__ as isize)
                                             > *ub.offset(i__ as isize)
@@ -1989,29 +2019,29 @@ unsafe extern "C" fn cobylb(
                                         }
                                         i__ += 1;
                                     }
-                                    if ifull == 0 as libc::c_int {
+                                    if ifull == 0 as ::core::ffi::c_int {
                                         temp = 0.0f64;
                                         i__1 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__1 {
                                             d__1 = *dx.offset(i__ as isize);
                                             temp += d__1 * d__1;
                                             i__ += 1;
                                         }
                                         if temp < rho * 0.25f64 * rho {
-                                            ibrnch = 1 as libc::c_int;
-                                            current_block = 17974563553836679504;
+                                            ibrnch = 1 as ::core::ffi::c_int;
+                                            current_block = 17164062518686415970;
                                             continue;
                                         }
                                     }
                                     resnew = 0.0f64;
                                     *con.offset(mp as isize) = 0.0f64;
                                     i__1 = mp;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__1 {
                                         sum = *con.offset(k as isize);
                                         i__2 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__2 {
                                             sum -= *a.offset((i__ + k * a_dim1) as isize)
                                                 * *dx.offset(i__ as isize);
@@ -2032,11 +2062,11 @@ unsafe extern "C" fn cobylb(
                                         break;
                                     }
                                     parmu = barmu * 2.0f64;
-                                    if *iprint >= 2 as libc::c_int {
+                                    if *iprint >= 2 as ::core::ffi::c_int {
                                         fprintf(
                                             stderr,
                                             b"cobyla: increase in PARMU to %12.6E\n\0" as *const u8
-                                                as *const libc::c_char,
+                                                as *const ::core::ffi::c_char,
                                             parmu,
                                         );
                                     }
@@ -2044,33 +2074,33 @@ unsafe extern "C" fn cobylb(
                                         + parmu
                                             * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     loop {
                                         if !(j <= i__1) {
-                                            break 'c_6122;
+                                            break '_L140;
                                         }
                                         temp = *datmat.offset((mp + j * datmat_dim1) as isize)
                                             + parmu
                                                 * *datmat.offset((*mpp + j * datmat_dim1) as isize);
                                         if temp < phi {
-                                            current_block = 16207618807156029286;
+                                            current_block = 9835236904106541358;
                                             break;
                                         }
-                                        if temp == phi && parmu == 0.0f32 as libc::c_double {
+                                        if temp == phi && parmu == 0.0f64 {
                                             if *datmat.offset((*mpp + j * datmat_dim1) as isize)
                                                 < *datmat.offset((*mpp + np * datmat_dim1) as isize)
                                             {
-                                                current_block = 16207618807156029286;
+                                                current_block = 9835236904106541358;
                                                 break;
                                             }
                                         }
                                         j += 1;
                                     }
                                 } else {
-                                    jdrop = 0 as libc::c_int;
+                                    jdrop = 0 as ::core::ffi::c_int;
                                     temp = pareta;
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         if *veta.offset(j as isize) > temp {
                                             jdrop = j;
@@ -2078,9 +2108,9 @@ unsafe extern "C" fn cobylb(
                                         }
                                         j += 1;
                                     }
-                                    if jdrop == 0 as libc::c_int {
+                                    if jdrop == 0 as ::core::ffi::c_int {
                                         i__1 = *n;
-                                        j = 1 as libc::c_int;
+                                        j = 1 as ::core::ffi::c_int;
                                         while j <= i__1 {
                                             if *vsig.offset(j as isize) < temp {
                                                 jdrop = j;
@@ -2091,7 +2121,7 @@ unsafe extern "C" fn cobylb(
                                     }
                                     temp = gamma_ * rho * *vsig.offset(jdrop as isize);
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *dx.offset(i__ as isize) =
                                             temp * *simi.offset((jdrop + i__ * simi_dim1) as isize);
@@ -2100,11 +2130,11 @@ unsafe extern "C" fn cobylb(
                                     cvmaxp = 0.0f64;
                                     cvmaxm = 0.0f64;
                                     i__1 = mp;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__1 {
                                         sum = 0.0f64;
                                         i__2 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__2 {
                                             sum += *a.offset((i__ + k * a_dim1) as isize)
                                                 * *dx.offset(i__ as isize);
@@ -2127,16 +2157,16 @@ unsafe extern "C" fn cobylb(
                                     }
                                     temp = 0.0f64;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *dx.offset(i__ as isize) = dxsign
                                             * *dx.offset(i__ as isize)
                                             * lcg_urand(
-                                                &mut seed,
+                                                &raw mut seed,
                                                 0.01f64,
-                                                1 as libc::c_int as libc::c_double,
+                                                1 as ::core::ffi::c_int as ::core::ffi::c_double,
                                             );
-                                        let mut xi: libc::c_double =
+                                        let mut xi: ::core::ffi::c_double =
                                             *sim.offset((i__ + np * sim_dim1) as isize);
                                         loop {
                                             if xi + *dx.offset(i__ as isize)
@@ -2167,18 +2197,18 @@ unsafe extern "C" fn cobylb(
                                         i__ += 1;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *simi.offset((jdrop + i__ * simi_dim1) as isize) /= temp;
                                         i__ += 1;
                                     }
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         if j != jdrop {
                                             temp = 0.0f64;
                                             i__2 = *n;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__2 {
                                                 temp += *simi
                                                     .offset((j + i__ * simi_dim1) as isize)
@@ -2186,7 +2216,7 @@ unsafe extern "C" fn cobylb(
                                                 i__ += 1;
                                             }
                                             i__2 = *n;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__2 {
                                                 *simi.offset((j + i__ * simi_dim1) as isize) -= temp
                                                     * *simi
@@ -2199,7 +2229,7 @@ unsafe extern "C" fn cobylb(
                                             + *dx.offset(j as isize);
                                         j += 1;
                                     }
-                                    continue 'c_6104;
+                                    continue '_L40;
                                 }
                             }
                         }
@@ -2207,20 +2237,20 @@ unsafe extern "C" fn cobylb(
                 }
                 prerem = parmu * prerec - sum;
                 i__1 = *n;
-                i__ = 1 as libc::c_int;
+                i__ = 1 as ::core::ffi::c_int;
                 while i__ <= i__1 {
                     *x.offset(i__ as isize) =
                         *sim.offset((i__ + np * sim_dim1) as isize) + *dx.offset(i__ as isize);
                     i__ += 1;
                 }
-                ibrnch = 1 as libc::c_int;
+                ibrnch = 1 as ::core::ffi::c_int;
             }
         }
     }
     match current_block {
-        16949430136398296108 => {
+        5794809869079527205 => {
             i__1 = *n;
-            i__ = 1 as libc::c_int;
+            i__ = 1 as ::core::ffi::c_int;
             while i__ <= i__1 {
                 *x.offset(i__ as isize) = *sim.offset((i__ + np * sim_dim1) as isize);
                 i__ += 1;
@@ -2231,25 +2261,28 @@ unsafe extern "C" fn cobylb(
         _ => {}
     }
     *minf = f;
-    if *iprint >= 1 as libc::c_int {
+    if *iprint >= 1 as ::core::ffi::c_int {
         fprintf(
             stderr,
             b"cobyla: NFVALS = %4d, F =%13.6E, MAXCV =%13.6E\n\0" as *const u8
-                as *const libc::c_char,
+                as *const ::core::ffi::c_char,
             *(*stop).nevals_p,
             f,
             resmax,
         );
         i__1 = iptem;
-        fprintf(stderr, b"cobyla: X =\0" as *const u8 as *const libc::c_char);
-        i__ = 1 as libc::c_int;
+        fprintf(
+            stderr,
+            b"cobyla: X =\0" as *const u8 as *const ::core::ffi::c_char,
+        );
+        i__ = 1 as ::core::ffi::c_int;
         while i__ <= i__1 {
-            if i__ > 1 as libc::c_int {
-                fprintf(stderr, b"  \0" as *const u8 as *const libc::c_char);
+            if i__ > 1 as ::core::ffi::c_int {
+                fprintf(stderr, b"  \0" as *const u8 as *const ::core::ffi::c_char);
             }
             fprintf(
                 stderr,
-                b"%13.6E\0" as *const u8 as *const libc::c_char,
+                b"%13.6E\0" as *const u8 as *const ::core::ffi::c_char,
                 *x.offset(i__ as isize),
             );
             i__ += 1;
@@ -2258,90 +2291,93 @@ unsafe extern "C" fn cobylb(
             i__1 = *n;
             i__ = iptemp;
             while i__ <= i__1 {
-                if (i__ - 1 as libc::c_int) % 4 as libc::c_int == 0 {
-                    fprintf(stderr, b"\ncobyla:  \0" as *const u8 as *const libc::c_char);
+                if (i__ - 1 as ::core::ffi::c_int) % 4 as ::core::ffi::c_int == 0 {
+                    fprintf(
+                        stderr,
+                        b"\ncobyla:  \0" as *const u8 as *const ::core::ffi::c_char,
+                    );
                 }
                 fprintf(
                     stderr,
-                    b"%15.6E\0" as *const u8 as *const libc::c_char,
+                    b"%15.6E\0" as *const u8 as *const ::core::ffi::c_char,
                     *x.offset(i__ as isize),
                 );
                 i__ += 1;
             }
         }
-        fprintf(stderr, b"\n\0" as *const u8 as *const libc::c_char);
+        fprintf(stderr, b"\n\0" as *const u8 as *const ::core::ffi::c_char);
     }
     return rc;
 }
 unsafe extern "C" fn trstlp(
-    mut n: *mut libc::c_int,
-    mut m: *mut libc::c_int,
-    mut a: *mut libc::c_double,
-    mut b: *mut libc::c_double,
-    mut rho: *mut libc::c_double,
-    mut dx: *mut libc::c_double,
-    mut ifull: *mut libc::c_int,
-    mut iact: *mut libc::c_int,
-    mut z__: *mut libc::c_double,
-    mut zdota: *mut libc::c_double,
-    mut vmultc: *mut libc::c_double,
-    mut sdirn: *mut libc::c_double,
-    mut dxnew: *mut libc::c_double,
-    mut vmultd: *mut libc::c_double,
+    mut n: *mut ::core::ffi::c_int,
+    mut m: *mut ::core::ffi::c_int,
+    mut a: *mut ::core::ffi::c_double,
+    mut b: *mut ::core::ffi::c_double,
+    mut rho: *mut ::core::ffi::c_double,
+    mut dx: *mut ::core::ffi::c_double,
+    mut ifull: *mut ::core::ffi::c_int,
+    mut iact: *mut ::core::ffi::c_int,
+    mut z__: *mut ::core::ffi::c_double,
+    mut zdota: *mut ::core::ffi::c_double,
+    mut vmultc: *mut ::core::ffi::c_double,
+    mut sdirn: *mut ::core::ffi::c_double,
+    mut dxnew: *mut ::core::ffi::c_double,
+    mut vmultd: *mut ::core::ffi::c_double,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut a_dim1: libc::c_int = 0;
-    let mut a_offset: libc::c_int = 0;
-    let mut z_dim1: libc::c_int = 0;
-    let mut z_offset: libc::c_int = 0;
-    let mut i__1: libc::c_int = 0;
-    let mut i__2: libc::c_int = 0;
-    let mut d__1: libc::c_double = 0.;
-    let mut d__2: libc::c_double = 0.;
-    let mut alpha: libc::c_double = 0.;
-    let mut tempa: libc::c_double = 0.;
-    let mut beta: libc::c_double = 0.;
-    let mut optnew: libc::c_double = 0.;
-    let mut stpful: libc::c_double = 0.;
-    let mut sum: libc::c_double = 0.;
-    let mut tot: libc::c_double = 0.;
-    let mut acca: libc::c_double = 0.;
-    let mut accb: libc::c_double = 0.;
-    let mut ratio: libc::c_double = 0.;
-    let mut vsave: libc::c_double = 0.;
-    let mut zdotv: libc::c_double = 0.;
-    let mut zdotw: libc::c_double = 0.;
-    let mut dd: libc::c_double = 0.;
-    let mut sd: libc::c_double = 0.;
-    let mut sp: libc::c_double = 0.;
-    let mut ss: libc::c_double = 0.;
-    let mut resold: libc::c_double = 0.0f64;
-    let mut zdvabs: libc::c_double = 0.;
-    let mut zdwabs: libc::c_double = 0.;
-    let mut sumabs: libc::c_double = 0.;
-    let mut resmax: libc::c_double = 0.;
-    let mut optold: libc::c_double = 0.;
-    let mut spabs: libc::c_double = 0.;
-    let mut temp: libc::c_double = 0.;
-    let mut step: libc::c_double = 0.;
-    let mut icount: libc::c_int = 0;
-    let mut i__: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut isave: libc::c_int = 0;
-    let mut kk: libc::c_int = 0;
-    let mut kl: libc::c_int = 0;
-    let mut kp: libc::c_int = 0;
-    let mut kw: libc::c_int = 0;
-    let mut nact: libc::c_int = 0;
-    let mut icon: libc::c_int = 0 as libc::c_int;
-    let mut mcon: libc::c_int = 0;
-    let mut nactx: libc::c_int = 0 as libc::c_int;
+    let mut a_dim1: ::core::ffi::c_int = 0;
+    let mut a_offset: ::core::ffi::c_int = 0;
+    let mut z_dim1: ::core::ffi::c_int = 0;
+    let mut z_offset: ::core::ffi::c_int = 0;
+    let mut i__1: ::core::ffi::c_int = 0;
+    let mut i__2: ::core::ffi::c_int = 0;
+    let mut d__1: ::core::ffi::c_double = 0.;
+    let mut d__2: ::core::ffi::c_double = 0.;
+    let mut alpha: ::core::ffi::c_double = 0.;
+    let mut tempa: ::core::ffi::c_double = 0.;
+    let mut beta: ::core::ffi::c_double = 0.;
+    let mut optnew: ::core::ffi::c_double = 0.;
+    let mut stpful: ::core::ffi::c_double = 0.;
+    let mut sum: ::core::ffi::c_double = 0.;
+    let mut tot: ::core::ffi::c_double = 0.;
+    let mut acca: ::core::ffi::c_double = 0.;
+    let mut accb: ::core::ffi::c_double = 0.;
+    let mut ratio: ::core::ffi::c_double = 0.;
+    let mut vsave: ::core::ffi::c_double = 0.;
+    let mut zdotv: ::core::ffi::c_double = 0.;
+    let mut zdotw: ::core::ffi::c_double = 0.;
+    let mut dd: ::core::ffi::c_double = 0.;
+    let mut sd: ::core::ffi::c_double = 0.;
+    let mut sp: ::core::ffi::c_double = 0.;
+    let mut ss: ::core::ffi::c_double = 0.;
+    let mut resold: ::core::ffi::c_double = 0.0f64;
+    let mut zdvabs: ::core::ffi::c_double = 0.;
+    let mut zdwabs: ::core::ffi::c_double = 0.;
+    let mut sumabs: ::core::ffi::c_double = 0.;
+    let mut resmax: ::core::ffi::c_double = 0.;
+    let mut optold: ::core::ffi::c_double = 0.;
+    let mut spabs: ::core::ffi::c_double = 0.;
+    let mut temp: ::core::ffi::c_double = 0.;
+    let mut step: ::core::ffi::c_double = 0.;
+    let mut icount: ::core::ffi::c_int = 0;
+    let mut i__: ::core::ffi::c_int = 0;
+    let mut j: ::core::ffi::c_int = 0;
+    let mut k: ::core::ffi::c_int = 0;
+    let mut isave: ::core::ffi::c_int = 0;
+    let mut kk: ::core::ffi::c_int = 0;
+    let mut kl: ::core::ffi::c_int = 0;
+    let mut kp: ::core::ffi::c_int = 0;
+    let mut kw: ::core::ffi::c_int = 0;
+    let mut nact: ::core::ffi::c_int = 0;
+    let mut icon: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut mcon: ::core::ffi::c_int = 0;
+    let mut nactx: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
     z_dim1 = *n;
-    z_offset = 1 as libc::c_int + z_dim1 * 1 as libc::c_int;
+    z_offset = 1 as ::core::ffi::c_int + z_dim1 * 1 as ::core::ffi::c_int;
     z__ = z__.offset(-(z_offset as isize));
     a_dim1 = *n;
-    a_offset = 1 as libc::c_int + a_dim1 * 1 as libc::c_int;
+    a_offset = 1 as ::core::ffi::c_int + a_dim1 * 1 as ::core::ffi::c_int;
     a = a.offset(-(a_offset as isize));
     b = b.offset(-1);
     dx = dx.offset(-1);
@@ -2351,15 +2387,15 @@ unsafe extern "C" fn trstlp(
     sdirn = sdirn.offset(-1);
     dxnew = dxnew.offset(-1);
     vmultd = vmultd.offset(-1);
-    *ifull = 1 as libc::c_int;
+    *ifull = 1 as ::core::ffi::c_int;
     mcon = *m;
-    nact = 0 as libc::c_int;
+    nact = 0 as ::core::ffi::c_int;
     resmax = 0.0f64;
     i__1 = *n;
-    i__ = 1 as libc::c_int;
+    i__ = 1 as ::core::ffi::c_int;
     while i__ <= i__1 {
         i__2 = *n;
-        j = 1 as libc::c_int;
+        j = 1 as ::core::ffi::c_int;
         while j <= i__2 {
             *z__.offset((i__ + j * z_dim1) as isize) = 0.0f64;
             j += 1;
@@ -2368,9 +2404,9 @@ unsafe extern "C" fn trstlp(
         *dx.offset(i__ as isize) = 0.0f64;
         i__ += 1;
     }
-    if *m >= 1 as libc::c_int {
+    if *m >= 1 as ::core::ffi::c_int {
         i__1 = *m;
-        k = 1 as libc::c_int;
+        k = 1 as ::core::ffi::c_int;
         while k <= i__1 {
             if *b.offset(k as isize) > resmax {
                 resmax = *b.offset(k as isize);
@@ -2379,7 +2415,7 @@ unsafe extern "C" fn trstlp(
             k += 1;
         }
         i__1 = *m;
-        k = 1 as libc::c_int;
+        k = 1 as ::core::ffi::c_int;
         while k <= i__1 {
             *iact.offset(k as isize) = k;
             *vmultc.offset(k as isize) = resmax - *b.offset(k as isize);
@@ -2387,51 +2423,51 @@ unsafe extern "C" fn trstlp(
         }
     }
     if resmax == 0.0f64 {
-        current_block = 11188143500741601598;
+        current_block = 7504792083021403859;
     } else {
         i__1 = *n;
-        i__ = 1 as libc::c_int;
+        i__ = 1 as ::core::ffi::c_int;
         while i__ <= i__1 {
             *sdirn.offset(i__ as isize) = 0.0f64;
             i__ += 1;
         }
-        current_block = 13859042411183768487;
+        current_block = 16752972209779365146;
     }
-    'c_8601: loop {
+    '_L480: loop {
         match current_block {
-            11188143500741601598 => {
-                mcon = *m + 1 as libc::c_int;
+            7504792083021403859 => {
+                mcon = *m + 1 as ::core::ffi::c_int;
                 icon = mcon;
                 *iact.offset(mcon as isize) = mcon;
                 *vmultc.offset(mcon as isize) = 0.0f64;
-                current_block = 13859042411183768487;
+                current_block = 16752972209779365146;
             }
             _ => {
                 optold = 0.0f64;
-                icount = 0 as libc::c_int;
+                icount = 0 as ::core::ffi::c_int;
                 loop {
                     if mcon == *m {
                         optnew = resmax;
                     } else {
                         optnew = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             optnew -= *dx.offset(i__ as isize)
                                 * *a.offset((i__ + mcon * a_dim1) as isize);
                             i__ += 1;
                         }
                     }
-                    if icount == 0 as libc::c_int || optnew < optold {
+                    if icount == 0 as ::core::ffi::c_int || optnew < optold {
                         optold = optnew;
                         nactx = nact;
-                        icount = 3 as libc::c_int;
+                        icount = 3 as ::core::ffi::c_int;
                     } else if nact > nactx {
                         nactx = nact;
-                        icount = 3 as libc::c_int;
+                        icount = 3 as ::core::ffi::c_int;
                     } else {
                         icount -= 1;
-                        if icount == 0 as libc::c_int {
+                        if icount == 0 as ::core::ffi::c_int {
                             break;
                         }
                     }
@@ -2441,11 +2477,11 @@ unsafe extern "C" fn trstlp(
                             vsave = *vmultc.offset(icon as isize);
                             k = icon;
                             loop {
-                                kp = k + 1 as libc::c_int;
+                                kp = k + 1 as ::core::ffi::c_int;
                                 kk = *iact.offset(kp as isize);
                                 sp = 0.0f64;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     sp += *z__.offset((i__ + k * z_dim1) as isize)
                                         * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2458,7 +2494,7 @@ unsafe extern "C" fn trstlp(
                                 *zdota.offset(kp as isize) = alpha * *zdota.offset(k as isize);
                                 *zdota.offset(k as isize) = temp;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = alpha * *z__.offset((i__ + kp * z_dim1) as isize)
                                         + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2480,33 +2516,33 @@ unsafe extern "C" fn trstlp(
                         }
                         nact -= 1;
                         if mcon > *m {
-                            current_block = 15623375721314334080;
+                            current_block = 12160513336339985658;
                         } else {
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *sdirn.offset(i__ as isize)
                                     * *z__.offset(
-                                        (i__ + (nact + 1 as libc::c_int) * z_dim1) as isize,
+                                        (i__ + (nact + 1 as ::core::ffi::c_int) * z_dim1) as isize,
                                     );
                                 i__ += 1;
                             }
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) -= temp
                                     * *z__.offset(
-                                        (i__ + (nact + 1 as libc::c_int) * z_dim1) as isize,
+                                        (i__ + (nact + 1 as ::core::ffi::c_int) * z_dim1) as isize,
                                     );
                                 i__ += 1;
                             }
-                            current_block = 9824026811267781195;
+                            current_block = 6113825314382560423;
                         }
                     } else {
                         kk = *iact.offset(icon as isize);
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *dxnew.offset(i__ as isize) = *a.offset((i__ + kk * a_dim1) as isize);
                             i__ += 1;
@@ -2517,7 +2553,7 @@ unsafe extern "C" fn trstlp(
                             sp = 0.0f64;
                             spabs = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp = *z__.offset((i__ + k * z_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2533,13 +2569,13 @@ unsafe extern "C" fn trstlp(
                             if tot == 0.0f64 {
                                 tot = sp;
                             } else {
-                                kp = k + 1 as libc::c_int;
+                                kp = k + 1 as ::core::ffi::c_int;
                                 temp = sqrt(sp * sp + tot * tot);
                                 alpha = sp / temp;
                                 beta = tot / temp;
                                 tot = temp;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = alpha * *z__.offset((i__ + k * z_dim1) as isize)
                                         + beta * *z__.offset((i__ + kp * z_dim1) as isize);
@@ -2564,7 +2600,7 @@ unsafe extern "C" fn trstlp(
                                 zdotv = 0.0f64;
                                 zdvabs = 0.0f64;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *z__.offset((i__ + k * z_dim1) as isize)
                                         * *dxnew.offset(i__ as isize);
@@ -2582,10 +2618,10 @@ unsafe extern "C" fn trstlp(
                                             ratio = tempa;
                                         }
                                     }
-                                    if k >= 2 as libc::c_int {
+                                    if k >= 2 as ::core::ffi::c_int {
                                         kw = *iact.offset(k as isize);
                                         i__1 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__1 {
                                             *dxnew.offset(i__ as isize) -=
                                                 temp * *a.offset((i__ + kw * a_dim1) as isize);
@@ -2597,7 +2633,7 @@ unsafe extern "C" fn trstlp(
                                     *vmultd.offset(k as isize) = 0.0f64;
                                 }
                                 k -= 1;
-                                if !(k > 0 as libc::c_int) {
+                                if !(k > 0 as ::core::ffi::c_int) {
                                     break;
                                 }
                             }
@@ -2605,7 +2641,7 @@ unsafe extern "C" fn trstlp(
                                 break;
                             }
                             i__1 = nact;
-                            k = 1 as libc::c_int;
+                            k = 1 as ::core::ffi::c_int;
                             while k <= i__1 {
                                 d__1 = 0.0f64;
                                 d__2 =
@@ -2618,11 +2654,11 @@ unsafe extern "C" fn trstlp(
                                 vsave = *vmultc.offset(icon as isize);
                                 k = icon;
                                 loop {
-                                    kp = k + 1 as libc::c_int;
+                                    kp = k + 1 as ::core::ffi::c_int;
                                     kw = *iact.offset(kp as isize);
                                     sp = 0.0f64;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         sp += *z__.offset((i__ + k * z_dim1) as isize)
                                             * *a.offset((i__ + kw * a_dim1) as isize);
@@ -2635,7 +2671,7 @@ unsafe extern "C" fn trstlp(
                                     *zdota.offset(kp as isize) = alpha * *zdota.offset(k as isize);
                                     *zdota.offset(k as isize) = temp;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         temp = alpha * *z__.offset((i__ + kp * z_dim1) as isize)
                                             + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2657,7 +2693,7 @@ unsafe extern "C" fn trstlp(
                             }
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *z__.offset((i__ + nact * z_dim1) as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2673,10 +2709,10 @@ unsafe extern "C" fn trstlp(
                         *iact.offset(icon as isize) = *iact.offset(nact as isize);
                         *iact.offset(nact as isize) = kk;
                         if mcon > *m && kk != mcon {
-                            k = nact - 1 as libc::c_int;
+                            k = nact - 1 as ::core::ffi::c_int;
                             sp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 sp += *z__.offset((i__ + k * z_dim1) as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2689,7 +2725,7 @@ unsafe extern "C" fn trstlp(
                             *zdota.offset(nact as isize) = alpha * *zdota.offset(k as isize);
                             *zdota.offset(k as isize) = temp;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp = alpha * *z__.offset((i__ + nact * z_dim1) as isize)
                                     + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2706,12 +2742,12 @@ unsafe extern "C" fn trstlp(
                             *vmultc.offset(nact as isize) = temp;
                         }
                         if mcon > *m {
-                            current_block = 15623375721314334080;
+                            current_block = 12160513336339985658;
                         } else {
                             kk = *iact.offset(nact as isize);
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *sdirn.offset(i__ as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2720,20 +2756,20 @@ unsafe extern "C" fn trstlp(
                             temp += -1.0f64;
                             temp /= *zdota.offset(nact as isize);
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) -=
                                     temp * *z__.offset((i__ + nact * z_dim1) as isize);
                                 i__ += 1;
                             }
-                            current_block = 9824026811267781195;
+                            current_block = 6113825314382560423;
                         }
                     }
                     match current_block {
-                        15623375721314334080 => {
+                        12160513336339985658 => {
                             temp = 1.0f64 / *zdota.offset(nact as isize);
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) =
                                     temp * *z__.offset((i__ + nact * z_dim1) as isize);
@@ -2746,10 +2782,10 @@ unsafe extern "C" fn trstlp(
                     sd = 0.0f64;
                     ss = 0.0f64;
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         d__1 = *dx.offset(i__ as isize);
-                        if fabs(d__1) >= *rho * 1e-6f32 as libc::c_double {
+                        if fabs(d__1) >= *rho * 1e-6f64 {
                             d__2 = *dx.offset(i__ as isize);
                             dd -= d__2 * d__2;
                         }
@@ -2762,7 +2798,7 @@ unsafe extern "C" fn trstlp(
                         break;
                     }
                     temp = sqrt(ss * dd);
-                    if fabs(sd) >= temp * 1e-6f32 as libc::c_double {
+                    if fabs(sd) >= temp * 1e-6f64 {
                         temp = sqrt(ss * dd + sd * sd);
                     }
                     stpful = dd / (temp + sd);
@@ -2771,8 +2807,8 @@ unsafe extern "C" fn trstlp(
                         acca = step + resmax * 0.1f64;
                         accb = step + resmax * 0.2f64;
                         if step >= acca || acca >= accb {
-                            current_block = 11188143500741601598;
-                            continue 'c_8601;
+                            current_block = 7504792083021403859;
+                            continue '_L480;
                         }
                         step = if step <= resmax { step } else { resmax };
                     }
@@ -2780,7 +2816,7 @@ unsafe extern "C" fn trstlp(
                         return NLOPT_ROUNDOFF_LIMITED;
                     }
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dxnew.offset(i__ as isize) =
                             *dx.offset(i__ as isize) + step * *sdirn.offset(i__ as isize);
@@ -2790,12 +2826,12 @@ unsafe extern "C" fn trstlp(
                         resold = resmax;
                         resmax = 0.0f64;
                         i__1 = nact;
-                        k = 1 as libc::c_int;
+                        k = 1 as ::core::ffi::c_int;
                         while k <= i__1 {
                             kk = *iact.offset(k as isize);
                             temp = *b.offset(kk as isize);
                             i__2 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__2 {
                                 temp -= *a.offset((i__ + kk * a_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2810,7 +2846,7 @@ unsafe extern "C" fn trstlp(
                         zdotw = 0.0f64;
                         zdwabs = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             temp = *z__.offset((i__ + k * z_dim1) as isize)
                                 * *dxnew.offset(i__ as isize);
@@ -2824,12 +2860,12 @@ unsafe extern "C" fn trstlp(
                             zdotw = 0.0f64;
                         }
                         *vmultd.offset(k as isize) = zdotw / *zdota.offset(k as isize);
-                        if !(k >= 2 as libc::c_int) {
+                        if !(k >= 2 as ::core::ffi::c_int) {
                             break;
                         }
                         kk = *iact.offset(k as isize);
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *dxnew.offset(i__ as isize) -= *vmultd.offset(k as isize)
                                 * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2843,14 +2879,14 @@ unsafe extern "C" fn trstlp(
                         *vmultd.offset(nact as isize) = if d__1 >= d__2 { d__1 } else { d__2 };
                     }
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dxnew.offset(i__ as isize) =
                             *dx.offset(i__ as isize) + step * *sdirn.offset(i__ as isize);
                         i__ += 1;
                     }
                     if mcon > nact {
-                        kl = nact + 1 as libc::c_int;
+                        kl = nact + 1 as ::core::ffi::c_int;
                         i__1 = mcon;
                         k = kl;
                         while k <= i__1 {
@@ -2859,7 +2895,7 @@ unsafe extern "C" fn trstlp(
                             d__1 = *b.offset(kk as isize);
                             sumabs = resmax + fabs(d__1);
                             i__2 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__2 {
                                 temp = *a.offset((i__ + kk * a_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2867,19 +2903,19 @@ unsafe extern "C" fn trstlp(
                                 sumabs += fabs(temp);
                                 i__ += 1;
                             }
-                            acca = sumabs + fabs(sum) * 0.1f32 as libc::c_double;
-                            accb = sumabs + fabs(sum) * 0.2f32 as libc::c_double;
+                            acca = sumabs + fabs(sum) * 0.1f64;
+                            accb = sumabs + fabs(sum) * 0.2f64;
                             if sumabs >= acca || acca >= accb {
-                                sum = 0.0f32 as libc::c_double;
+                                sum = 0.0f64;
                             }
                             *vmultd.offset(k as isize) = sum;
                             k += 1;
                         }
                     }
                     ratio = 1.0f64;
-                    icon = 0 as libc::c_int;
+                    icon = 0 as ::core::ffi::c_int;
                     i__1 = mcon;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         if *vmultd.offset(k as isize) < 0.0f64 {
                             temp = *vmultc.offset(k as isize)
@@ -2893,14 +2929,14 @@ unsafe extern "C" fn trstlp(
                     }
                     temp = 1.0f64 - ratio;
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dx.offset(i__ as isize) =
                             temp * *dx.offset(i__ as isize) + ratio * *dxnew.offset(i__ as isize);
                         i__ += 1;
                     }
                     i__1 = mcon;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         d__1 = 0.0f64;
                         d__2 =
@@ -2911,24 +2947,26 @@ unsafe extern "C" fn trstlp(
                     if mcon == *m {
                         resmax = resold + ratio * (resmax - resold);
                     }
-                    if icon > 0 as libc::c_int {
+                    if icon > 0 as ::core::ffi::c_int {
                         continue;
                     }
                     if step == stpful {
-                        break 'c_8601;
+                        break '_L480;
                     } else {
-                        current_block = 11188143500741601598;
-                        continue 'c_8601;
+                        current_block = 7504792083021403859;
+                        continue '_L480;
                     }
                 }
                 if mcon == *m {
-                    current_block = 11188143500741601598;
+                    current_block = 7504792083021403859;
                     continue;
                 }
-                *ifull = 0 as libc::c_int;
+                *ifull = 0 as ::core::ffi::c_int;
                 break;
             }
         }
     }
     return NLOPT_SUCCESS;
 }
+pub const DBL_MAX: ::core::ffi::c_double = __DBL_MAX__;
+pub const __DBL_MAX__: ::core::ffi::c_double = 1.7976931348623157e+308f64;

--- a/cobyla/nlopt/compile_commands.json
+++ b/cobyla/nlopt/compile_commands.json
@@ -1,7 +1,7 @@
 [
-{
-  "directory": "/stck/rlafage/tmp_user/workspace/cobyla/build",
-  "command": "/usr/bin/cc  -I/stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt  -o CMakeFiles/cobyla.dir/cobyla.c.o -c /stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt/cobyla.c",
-  "file": "/stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt/cobyla.c"
-}
+  {
+    "directory": "/tmp_user/juno/rlafage/workspace/cobyla/build",
+    "command": "/usr/bin/cc  -I/tmp_user/juno/rlafage/workspace/cobyla/cobyla/nlopt  -o CMakeFiles/cobyla.dir/cobyla.c.o -c /tmp_user/juno/rlafage/workspace/cobyla/cobyla/nlopt/cobyla.c",
+    "file": "/tmp_user/juno/rlafage/workspace/cobyla/cobyla/nlopt/cobyla.c"
+  }
 ]

--- a/cobyla/nlopt/compile_commands.json
+++ b/cobyla/nlopt/compile_commands.json
@@ -1,7 +1,7 @@
 [
 {
-  "directory": "/home/rlafage/workspace/cobyla/build",
-  "command": "/usr/bin/cc  -I/home/rlafage/workspace/cobyla/cobyla    -o CMakeFiles/cobyla.dir/cobyla.c.o   -c /home/rlafage/workspace/cobyla/cobyla/cobyla.c",
-  "file": "/home/rlafage/workspace/cobyla/cobyla/cobyla.c"
+  "directory": "/stck/rlafage/tmp_user/workspace/cobyla/build",
+  "command": "/usr/bin/cc  -I/stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt  -o CMakeFiles/cobyla.dir/cobyla.c.o -c /stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt/cobyla.c",
+  "file": "/stck/rlafage/tmp_user/workspace/cobyla/cobyla/nlopt/cobyla.c"
 }
 ]

--- a/cobyla/nlopt/nlopt-util.h
+++ b/cobyla/nlopt/nlopt-util.h
@@ -37,10 +37,12 @@
 #endif
 
 #ifndef HAVE_COPYSIGN
+#if !defined(__cplusplus) && __STDC_VERSION__ < 199901
    /* not quite right for y == -0, but good enough for us */
 #  define copysign(x, y) ((y) < 0 ? -fabs(x) : fabs(x))
-#elif !defined(__cplusplus) && __STDC_VERSION__ < 199901
+#else
 extern double copysign(double x, double y); /* may not be declared in C89 */
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/cobyla/nlopt/timer.c
+++ b/cobyla/nlopt/timer.c
@@ -51,7 +51,7 @@ double nlopt_seconds(void)
     gettimeofday(&tv, NULL);
     return (tv.tv_sec - start.tv_sec) + 1.e-6 * (tv.tv_usec - start.tv_usec);
 #elif defined(HAVE_TIME)
-    return time(NULL);
+    return (double)time(NULL);
 #elif defined(_WIN32) || defined(__WIN32__)
     static THREADLOCAL ULONGLONG start;
     FILETIME ft;
@@ -82,7 +82,7 @@ unsigned long nlopt_time_seed(void)
     gettimeofday(&tv, NULL);
     return (tv.tv_sec ^ tv.tv_usec);
 #elif defined(HAVE_TIME)
-    return time(NULL);
+    return (unsigned long)time(NULL);
 #elif defined(_WIN32) || defined(__WIN32__)
     FILETIME ft;
     GetSystemTimeAsFileTime(&ft);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,15 +343,15 @@ mod tests {
     // Second problem (see cobyla.c case 6)
 
     fn raw_paraboloid(
-        _n: libc::c_uint,
-        x: *const libc::c_double,
-        _gradient: *mut libc::c_double,
-        _func_data: *mut libc::c_void,
-    ) -> libc::c_double {
+        _n: ::core::ffi::c_uint,
+        x: *const ::core::ffi::c_double,
+        _gradient: *mut ::core::ffi::c_double,
+        _func_data: *mut ::core::ffi::c_void,
+    ) -> ::core::ffi::c_double {
         unsafe {
             let r1 = *x.offset(0) + 1.0;
             let r2 = *x.offset(1);
-            10.0 * (r1 * r1) + (r2 * r2) as libc::c_double
+            10.0 * (r1 * r1) + (r2 * r2) as ::core::ffi::c_double
         }
     }
 

--- a/src/nlopt_cobyla.rs
+++ b/src/nlopt_cobyla.rs
@@ -1,6 +1,5 @@
 #![allow(
     dead_code,
-    mutable_transmutes,
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
@@ -124,8 +123,8 @@ struct __va_list_tag {
     pub overflow_arg_area: *mut ::core::ffi::c_void,
     pub reg_save_area: *mut ::core::ffi::c_void,
 }
-type size_t = ::core::ffi::c_ulong;
-type __uint32_t = ::core::ffi::c_uint;
+type size_t = usize;
+type __uint32_t = u32;
 type __off_t = ::core::ffi::c_long;
 type __off64_t = ::core::ffi::c_long;
 type __time_t = ::core::ffi::c_long;
@@ -272,47 +271,6 @@ const COBYLA_MSG_INFO: C2RustUnnamed = 3;
 const COBYLA_MSG_ITER: C2RustUnnamed = 2;
 const COBYLA_MSG_EXIT: C2RustUnnamed = 1;
 
-unsafe fn nlopt_time_seed() -> ::core::ffi::c_ulong {
-    // let mut tv = ::core::ffi::timeval {
-    //     tv_sec: 0,
-    //     tv_usec: 0,
-    // };
-    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
-    //return (tv.tv_sec ^ tv.tv_usec) as ::core::ffi::c_ulong;
-    let start = SystemTime::now();
-    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time flies");
-    since_the_epoch.as_millis() as ::core::ffi::c_ulong
-}
-
-unsafe fn nlopt_seconds() -> ::core::ffi::c_double {
-    // static mut start_inited: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
-    // static mut start: ::core::ffi::timeval = ::core::ffi::timeval {
-    //     tv_sec: 0,
-    //     tv_usec: 0,
-    // };
-    // let mut tv: ::core::ffi::timeval = ::core::ffi::timeval {
-    //     tv_sec: 0,
-    //     tv_usec: 0,
-    // };
-    // if start_inited == 0 {
-    //     start_inited = 1 as ::core::ffi::c_int;
-    //     ::core::ffi::gettimeofday(&mut start, 0 as *mut ::core::ffi::timezone);
-    // }
-    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
-    // return (tv.tv_sec - start.tv_sec) as ::core::ffi::c_double
-    //     + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as ::core::ffi::c_double;
-    static mut start_inited: bool = false;
-    static mut start: SystemTime = UNIX_EPOCH;
-    if !start_inited {
-        start_inited = true;
-        start = SystemTime::now();
-    }
-    #[allow(static_mut_refs)]
-    start
-        .duration_since(UNIX_EPOCH)
-        .expect("Time flies")
-        .as_secs_f64()
-}
 unsafe fn sc(
     mut x: ::core::ffi::c_double,
     mut smin: ::core::ffi::c_double,
@@ -331,7 +289,7 @@ unsafe fn vector_norm(
     let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * (sc(
@@ -343,7 +301,7 @@ unsafe fn vector_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += (sc(
                     *vec.offset(i as isize),
@@ -355,13 +313,13 @@ unsafe fn vector_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * (*vec.offset(i as isize)).abs();
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += (*vec.offset(i as isize)).abs();
             i = i.wrapping_add(1);
@@ -381,7 +339,7 @@ unsafe fn diff_norm(
     let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * (sc(
@@ -397,7 +355,7 @@ unsafe fn diff_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+            i = 0 as ::core::ffi::c_uint;
             while i < n {
                 ret += (sc(
                     *x.offset(i as isize),
@@ -413,13 +371,13 @@ unsafe fn diff_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * (*x.offset(i as isize) - *oldx.offset(i as isize)).abs();
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             ret += (*x.offset(i as isize) - *oldx.offset(i as isize)).abs();
             i = i.wrapping_add(1);
@@ -468,15 +426,15 @@ unsafe fn nlopt_stop_x(
         x,
         oldx,
         (*s).x_weights,
-        0 as *const ::core::ffi::c_double,
-        0 as *const ::core::ffi::c_double,
+        ::core::ptr::null::<::core::ffi::c_double>(),
+        ::core::ptr::null::<::core::ffi::c_double>(),
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const ::core::ffi::c_double,
-            0 as *const ::core::ffi::c_double,
+            ::core::ptr::null::<::core::ffi::c_double>(),
+            ::core::ptr::null::<::core::ffi::c_double>(),
         )
     {
         return 1 as ::core::ffi::c_int;
@@ -484,7 +442,7 @@ unsafe fn nlopt_stop_x(
     if ((*s).xtol_abs).is_null() {
         return 0 as ::core::ffi::c_int;
     }
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
         if (*x.offset(i as isize) - *oldx.offset(i as isize)).abs()
             >= *((*s).xtol_abs).offset(i as isize)
@@ -506,23 +464,23 @@ unsafe fn nlopt_stop_dx(
         (*s).n,
         dx,
         (*s).x_weights,
-        0 as *const ::core::ffi::c_double,
-        0 as *const ::core::ffi::c_double,
+        ::core::ptr::null::<::core::ffi::c_double>(),
+        ::core::ptr::null::<::core::ffi::c_double>(),
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const ::core::ffi::c_double,
-            0 as *const ::core::ffi::c_double,
+            ::core::ptr::null::<::core::ffi::c_double>(),
+            ::core::ptr::null::<::core::ffi::c_double>(),
         )
     {
         return 1 as ::core::ffi::c_int;
     }
-    if ((*s).xtol_abs).is_null() {
+    if (*s).xtol_abs.is_null() {
         return 0 as ::core::ffi::c_int;
     }
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
         if (*dx.offset(i as isize)).abs() >= *((*s).xtol_abs).offset(i as isize) {
             return 0 as ::core::ffi::c_int;
@@ -545,10 +503,10 @@ unsafe fn nlopt_stop_xs(
     {
         return 1 as ::core::ffi::c_int;
     }
-    if ((*s).xtol_abs).is_null() {
+    if (*s).xtol_abs.is_null() {
         return 0 as ::core::ffi::c_int;
     }
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < (*s).n {
         if (sc(
             *xs.offset(i as isize),
@@ -569,30 +527,7 @@ unsafe fn nlopt_stop_xs(
     return 1 as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_isinf(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
-    return ((x).abs() >= f64::INFINITY * 0.99f64
-        || if x.is_infinite() {
-            if x.is_sign_positive() { 1 } else { -1 }
-        } else {
-            0
-        } != 0) as ::core::ffi::c_int;
-}
 
-unsafe fn nlopt_isfinite(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
-    return (x.abs() <= 1.7976931348623157e+308f64) as ::core::ffi::c_int;
-}
-
-unsafe fn nlopt_istiny(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
-    if x == 0.0f64 {
-        return 1 as ::core::ffi::c_int;
-    } else {
-        return (x.abs() < 2.2250738585072014e-308f64) as ::core::ffi::c_int;
-    };
-}
-
-unsafe fn nlopt_isnan(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
-    return x.is_nan() as i32;
-}
 
 unsafe fn nlopt_stop_evals(mut s: *const nlopt_stopping) -> ::core::ffi::c_int {
     return ((*s).maxeval > 0 as ::core::ffi::c_int && *(*s).nevals_p >= (*s).maxeval) as ::core::ffi::c_int;
@@ -644,17 +579,13 @@ unsafe fn nlopt_stop_forced(mut stop: *const nlopt_stopping) -> ::core::ffi::c_i
 //     return p;
 // }
 
-unsafe fn nlopt_stop_msg(mut s: *mut nlopt_stopping, msg: &str) {
-    (*s).stop_msg = msg.to_string();
-}
-
 unsafe fn nlopt_count_constraints(
     mut p: ::core::ffi::c_uint,
     mut c: *const nlopt_constraint,
 ) -> ::core::ffi::c_uint {
     let mut i: ::core::ffi::c_uint = 0;
-    let mut count: ::core::ffi::c_uint = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let mut count: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < p {
         count = count.wrapping_add((*c.offset(i as isize)).m);
         i = i.wrapping_add(1);
@@ -667,8 +598,8 @@ unsafe fn nlopt_max_constraint_dim(
     mut c: *const nlopt_constraint,
 ) -> ::core::ffi::c_uint {
     let mut i: ::core::ffi::c_uint = 0;
-    let mut max_dim: ::core::ffi::c_uint = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    let mut max_dim: ::core::ffi::c_uint = 0 as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < p {
         if (*c.offset(i as isize)).m > max_dim {
             max_dim = (*c.offset(i as isize)).m;
@@ -685,7 +616,7 @@ unsafe fn nlopt_eval_constraint<U>(
     mut n: ::core::ffi::c_uint,
     mut x: *const ::core::ffi::c_double,
 ) {
-    if ((*c).f).is_some() {
+    if (*c).f.is_some() {
         *result.offset(0 as ::core::ffi::c_int as isize) =
         // PATCH Weird bug ((*c).f).expect("non-null function pointer") calls the objective function!!!
         // even if (*c), nlopt_constraint object was correctly built with a nlopt_constraint_raw_callback!!! 
@@ -695,11 +626,70 @@ unsafe fn nlopt_eval_constraint<U>(
         // relf: Take the opposite to manage cstr as being nonnegative in the end like the original cobyla
         *result.offset(0 as ::core::ffi::c_int as isize) = -*result.offset(0 as ::core::ffi::c_int as isize)
     } else {
-        ((*c).mf).expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);
+        (*c).mf.expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);
+    };
+}
+// #[no_mangle]
+// pub unsafe extern "C" fn nlopt_vsprintf(
+//     mut p: *mut ::core::ffi::c_char,
+//     mut format: *const ::core::ffi::c_char,
+//     mut ap: ::core::ffi::VaList,
+// ) -> *mut ::core::ffi::c_char {
+//     let mut len: size_t = strlen(format).wrapping_add(128 as size_t);
+//     let mut ret: ::core::ffi::c_int = 0;
+//     p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
+//     if p.is_null() {
+//         abort();
+//     }
+//     loop {
+//         ret = vsnprintf(p, len, format, ap.as_va_list());
+//         if !(ret < 0 as ::core::ffi::c_int || ret as size_t >= len) {
+//             break;
+//         }
+//         len = if ret >= 0 as ::core::ffi::c_int {
+//             (ret + 1 as ::core::ffi::c_int) as size_t
+//         } else {
+//             len.wrapping_mul(3 as size_t) >> 1 as ::core::ffi::c_int
+//         };
+//         p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
+//         if p.is_null() {
+//             abort();
+//         }
+//     }
+//     return p;
+// }
+
+
+unsafe fn nlopt_stop_msg(mut s: *mut nlopt_stopping, msg: &str) {
+    (*s).stop_msg = msg.to_string();
+}
+
+unsafe fn nlopt_isinf(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return ((x).abs() >= f64::INFINITY * 0.99f64
+        || if x.is_infinite() {
+            if x.is_sign_positive() { 1 } else { -1 }
+        } else {
+            0
+        } != 0) as ::core::ffi::c_int;
+}
+
+unsafe fn nlopt_isfinite(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return (x.abs() <= 1.7976931348623157e+308f64) as ::core::ffi::c_int;
+}
+
+unsafe fn nlopt_istiny(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    if x == 0.0f64 {
+        return 1 as ::core::ffi::c_int;
+    } else {
+        return (x.abs() < 2.2250738585072014e-308f64) as ::core::ffi::c_int;
     };
 }
 
-unsafe fn nlopt_compute_rescaling(
+unsafe fn nlopt_isnan(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return x.is_nan() as i32;
+}
+
+pub unsafe fn nlopt_compute_rescaling(
     mut n: ::core::ffi::c_uint,
     mut dx: *const ::core::ffi::c_double,
 ) -> *mut ::core::ffi::c_double {
@@ -713,25 +703,24 @@ unsafe fn nlopt_compute_rescaling(
 
     let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        return 0 as *mut ::core::ffi::c_double;
+        return ::core::ptr::null_mut::<::core::ffi::c_double>();
     }
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < n {
         *s.offset(i as isize) = 1.0f64;
         i = i.wrapping_add(1);
     }
-    if n == 1 as ::core::ffi::c_int as ::core::ffi::c_uint {
+    if n == 1 as ::core::ffi::c_uint {
         return s;
     }
-    i = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 1 as ::core::ffi::c_uint;
     while i < n
-        && *dx.offset(i as isize)
-            == *dx.offset(i.wrapping_sub(1 as ::core::ffi::c_int as ::core::ffi::c_uint) as isize)
+        && *dx.offset(i as isize) == *dx.offset(i.wrapping_sub(1 as ::core::ffi::c_uint) as isize)
     {
         i = i.wrapping_add(1);
     }
     if i < n {
-        i = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 1 as ::core::ffi::c_uint;
         while i < n {
             *s.offset(i as isize) = *dx.offset(i as isize) / *dx.offset(0 as ::core::ffi::c_int as isize);
             i = i.wrapping_add(1);
@@ -748,13 +737,13 @@ unsafe fn nlopt_rescale(
 ) {
     let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) / *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -770,13 +759,13 @@ unsafe fn nlopt_unscale(
 ) {
     let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        i = 0 as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) * *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -798,7 +787,7 @@ unsafe fn nlopt_new_rescaled(
     std::mem::forget(space);
 
     if xs.is_null() {
-        return 0 as *mut ::core::ffi::c_double;
+        return ::core::ptr::null_mut::<::core::ffi::c_double>();
     }
     nlopt_rescale(n, s, x, xs);
     return xs;
@@ -810,7 +799,7 @@ unsafe fn nlopt_reorder_bounds(
     mut ub: *mut ::core::ffi::c_double,
 ) {
     let mut i: ::core::ffi::c_uint = 0;
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
     while i < n {
         if *lb.offset(i as isize) > *ub.offset(i as isize) {
             let mut t: ::core::ffi::c_double = *lb.offset(i as isize);
@@ -820,6 +809,48 @@ unsafe fn nlopt_reorder_bounds(
         i = i.wrapping_add(1);
     }
 }
+unsafe fn nlopt_time_seed() -> ::core::ffi::c_ulong {
+    // let mut tv = ::core::ffi::timeval {
+    //     tv_sec: 0,
+    //     tv_usec: 0,
+    // };
+    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
+    //return (tv.tv_sec ^ tv.tv_usec) as ::core::ffi::c_ulong;
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time flies");
+    since_the_epoch.as_millis() as ::core::ffi::c_ulong
+}
+
+unsafe fn nlopt_seconds() -> ::core::ffi::c_double {
+    // static mut start_inited: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    // static mut start: ::core::ffi::timeval = ::core::ffi::timeval {
+    //     tv_sec: 0,
+    //     tv_usec: 0,
+    // };
+    // let mut tv: ::core::ffi::timeval = ::core::ffi::timeval {
+    //     tv_sec: 0,
+    //     tv_usec: 0,
+    // };
+    // if start_inited == 0 {
+    //     start_inited = 1 as ::core::ffi::c_int;
+    //     ::core::ffi::gettimeofday(&mut start, 0 as *mut ::core::ffi::timezone);
+    // }
+    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
+    // return (tv.tv_sec - start.tv_sec) as ::core::ffi::c_double
+    //     + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as ::core::ffi::c_double;
+    static mut start_inited: bool = false;
+    static mut start: SystemTime = UNIX_EPOCH;
+    if !start_inited {
+        start_inited = true;
+        start = SystemTime::now();
+    }
+    #[allow(static_mut_refs)]
+    start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time flies")
+        .as_secs_f64()
+}
+
 unsafe fn func_wrap<U>(
     mut ni: ::core::ffi::c_int,
     mut _mi: ::core::ffi::c_int,
@@ -835,7 +866,7 @@ unsafe fn func_wrap<U>(
     let mut xtmp: *mut ::core::ffi::c_double = (*s).xtmp;
     let mut lb: *const ::core::ffi::c_double = (*s).lb;
     let mut ub: *const ::core::ffi::c_double = (*s).ub;
-    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < n {
         if *x.offset(j as isize) < *lb.offset(j as isize) {
             *xtmp.offset(j as isize) = *lb.offset(j as isize);
@@ -847,72 +878,70 @@ unsafe fn func_wrap<U>(
         j = j.wrapping_add(1);
     }
     nlopt_unscale(n, (*s).scale, xtmp, xtmp);
-    *f = ((*s).f).expect("non-null function pointer")(
+    *f = (*s).f.expect("non-null function pointer")(
         n,
         xtmp,
-        0 as *mut ::core::ffi::c_double,
+        ::core::ptr::null_mut::<::core::ffi::c_double>(),
         (*s).f_data,
     );
     if nlopt_stop_forced((*s).stop) != 0 {
         return 1 as ::core::ffi::c_int;
     }
-    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
-    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < (*s).m_orig {
         nlopt_eval_constraint::<U>(
             con.offset(i as isize),
-            0 as *mut ::core::ffi::c_double,
-            ((*s).fc).offset(j as isize),
+            ::core::ptr::null_mut::<::core::ffi::c_double>(),
+            (*s).fc.offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
             return 1 as ::core::ffi::c_int;
         }
-        k = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
-        while k < (*((*s).fc).offset(j as isize)).m {
+        k = 0 as ::core::ffi::c_uint;
+        while k < (*(*s).fc.offset(j as isize)).m {
             *con.offset(i.wrapping_add(k) as isize) = -*con.offset(i.wrapping_add(k) as isize);
             k = k.wrapping_add(1);
         }
-        i = i.wrapping_add((*((*s).fc).offset(j as isize)).m);
+        i = i.wrapping_add((*(*s).fc.offset(j as isize)).m);
         j = j.wrapping_add(1);
     }
-    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < (*s).p {
         nlopt_eval_constraint::<U>(
             con.offset(i as isize),
-            0 as *mut ::core::ffi::c_double,
-            ((*s).h).offset(j as isize),
+            ::core::ptr::null_mut::<::core::ffi::c_double>(),
+            (*s).h.offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
             return 1 as ::core::ffi::c_int;
         }
-        k = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
-        while k < (*((*s).h).offset(j as isize)).m {
+        k = 0 as ::core::ffi::c_uint;
+        while k < (*(*s).h.offset(j as isize)).m {
             *con.offset(
-                i.wrapping_add((*((*s).h).offset(j as isize)).m)
+                i.wrapping_add((*(*s).h.offset(j as isize)).m)
                     .wrapping_add(k) as isize,
             ) = -*con.offset(i.wrapping_add(k) as isize);
             k = k.wrapping_add(1);
         }
-        i = i.wrapping_add(
-            (2 as ::core::ffi::c_int as ::core::ffi::c_uint).wrapping_mul((*((*s).h).offset(j as isize)).m),
-        );
+        i = i.wrapping_add((2 as ::core::ffi::c_uint).wrapping_mul((*(*s).h.offset(j as isize)).m));
         j = j.wrapping_add(1);
     }
-    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_uint;
     while j < n {
         if nlopt_isinf(*lb.offset(j as isize)) == 0 {
-            let fresh1 = i;
+            let fresh0 = i;
             i = i.wrapping_add(1);
-            *con.offset(fresh1 as isize) = *x.offset(j as isize) - *lb.offset(j as isize);
+            *con.offset(fresh0 as isize) = *x.offset(j as isize) - *lb.offset(j as isize);
         }
         if nlopt_isinf(*ub.offset(j as isize)) == 0 {
-            let fresh2 = i;
+            let fresh1 = i;
             i = i.wrapping_add(1);
-            *con.offset(fresh2 as isize) = *ub.offset(j as isize) - *x.offset(j as isize);
+            *con.offset(fresh1 as isize) = *ub.offset(j as isize) - *x.offset(j as isize);
         }
         j = j.wrapping_add(1);
     }
@@ -938,17 +967,17 @@ pub(crate) unsafe fn cobyla_minimize<U>(
     let mut j: ::core::ffi::c_uint = 0;
     let mut s: func_wrap_state = func_wrap_state {
         f: None,
-        f_data: 0 as *mut ::core::ffi::c_void,
+        f_data: ::core::ptr::null_mut::<::core::ffi::c_void>(),
         m_orig: 0,
-        fc: 0 as *mut nlopt_constraint,
+        fc: ::core::ptr::null_mut::<nlopt_constraint>(),
         p: 0,
-        h: 0 as *mut nlopt_constraint,
-        xtmp: 0 as *mut ::core::ffi::c_double,
-        lb: 0 as *mut ::core::ffi::c_double,
-        ub: 0 as *mut ::core::ffi::c_double,
-        con_tol: 0 as *mut ::core::ffi::c_double,
-        scale: 0 as *mut ::core::ffi::c_double,
-        stop: 0 as *mut nlopt_stopping,
+        h: ::core::ptr::null_mut::<nlopt_constraint>(),
+        xtmp: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        lb: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        ub: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        con_tol: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        scale: ::core::ptr::null_mut::<::core::ffi::c_double>(),
+        stop: ::core::ptr::null_mut::<nlopt_stopping>(),
     };
     let mut ret: nlopt_result = 0 as nlopt_result;
     let mut rhobeg: ::core::ffi::c_double = 0.;
@@ -960,23 +989,23 @@ pub(crate) unsafe fn cobyla_minimize<U>(
     s.p = p;
     s.h = h;
     s.stop = stop;
-    s.scale = 0 as *mut ::core::ffi::c_double;
+    s.scale = ::core::ptr::null_mut::<::core::ffi::c_double>();
     s.con_tol = s.scale;
     s.xtmp = s.con_tol;
     s.ub = s.xtmp;
     s.lb = s.ub;
     s.scale = nlopt_compute_rescaling(n, dx);
-    if (s.scale).is_null() {
+    if s.scale.is_null() {
         ret = NLOPT_OUT_OF_MEMORY;
     } else {
-        j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+        j = 0 as ::core::ffi::c_uint;
         loop {
             if !(j < n) {
-                current_block = 15652330335145281839;
+                current_block = 12800627514080957624;
                 break;
             }
-            if *(s.scale).offset(j as isize) == 0 as ::core::ffi::c_int as ::core::ffi::c_double
-                || nlopt_isfinite(*(s.scale).offset(j as isize)) == 0
+            if *s.scale.offset(j as isize) == 0 as ::core::ffi::c_int as ::core::ffi::c_double
+                || nlopt_isfinite(*s.scale.offset(j as isize)) == 0
             {
                 nlopt_stop_msg(
                     stop,
@@ -987,21 +1016,21 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                     ),
                 );
                 ret = NLOPT_INVALID_ARGS;
-                current_block = 762786280471819104;
+                current_block = 2538622867173152133;
                 break;
             } else {
                 j = j.wrapping_add(1);
             }
         }
         match current_block {
-            762786280471819104 => {}
+            2538622867173152133 => {}
             _ => {
                 s.lb = nlopt_new_rescaled(n, s.scale, lb);
-                if (s.lb).is_null() {
+                if s.lb.is_null() {
                     ret = NLOPT_OUT_OF_MEMORY;
                 } else {
                     s.ub = nlopt_new_rescaled(n, s.scale, ub);
-                    if (s.ub).is_null() {
+                    if s.ub.is_null() {
                         ret = NLOPT_OUT_OF_MEMORY;
                     } else {
                         nlopt_reorder_bounds(n, s.lb, s.ub);
@@ -1022,8 +1051,8 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                 / *(s.scale).offset(0 as ::core::ffi::c_int as isize))
                             .abs();
                             rhoend = (*stop).xtol_rel * rhobeg;
-                            if !((*stop).xtol_abs).is_null() {
-                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                            if !(*stop).xtol_abs.is_null() {
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < n {
                                     if rhoend
                                         < *((*stop).xtol_abs).offset(j as isize)
@@ -1035,11 +1064,11 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                     j = j.wrapping_add(1);
                                 }
                             }
-                            m = (nlopt_count_constraints(m, fc)).wrapping_add(
-                                (2 as ::core::ffi::c_int as ::core::ffi::c_uint)
+                            m = nlopt_count_constraints(m, fc).wrapping_add(
+                                (2 as ::core::ffi::c_uint)
                                     .wrapping_mul(nlopt_count_constraints(p, h)),
                             );
-                            j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                            j = 0 as ::core::ffi::c_uint;
                             while j < n {
                                 if nlopt_isinf(*lb.offset(j as isize)) == 0 {
                                     m = m.wrapping_add(1);
@@ -1064,43 +1093,43 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                             if m != 0 && (s.con_tol).is_null() {
                                 ret = NLOPT_OUT_OF_MEMORY;
                             } else {
-                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < m {
-                                    *(s.con_tol).offset(j as isize) =
+                                    *s.con_tol.offset(j as isize) =
                                         0 as ::core::ffi::c_int as ::core::ffi::c_double;
                                     j = j.wrapping_add(1);
                                 }
-                                i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                                i = 0 as ::core::ffi::c_uint;
                                 j = i;
                                 while i < s.m_orig {
                                     let mut ji: ::core::ffi::c_uint = j;
                                     let mut jnext: ::core::ffi::c_uint =
                                         j.wrapping_add((*fc.offset(i as isize)).m);
                                     while j < jnext {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*fc.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*fc.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     i = i.wrapping_add(1);
                                 }
-                                i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                                i = 0 as ::core::ffi::c_uint;
                                 while i < s.p {
                                     let mut ji_0: ::core::ffi::c_uint = j;
                                     let mut jnext_0: ::core::ffi::c_uint =
                                         j.wrapping_add((*h.offset(i as isize)).m);
                                     while j < jnext_0 {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*h.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji_0) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*h.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji_0) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     ji_0 = j;
                                     jnext_0 = j.wrapping_add((*h.offset(i as isize)).m);
                                     while j < jnext_0 {
-                                        *(s.con_tol).offset(j as isize) =
-                                            *((*h.offset(i as isize)).tol)
-                                                .offset(j.wrapping_sub(ji_0) as isize);
+                                        *s.con_tol.offset(j as isize) = *(*h.offset(i as isize))
+                                            .tol
+                                            .offset(j.wrapping_sub(ji_0) as isize);
                                         j = j.wrapping_add(1);
                                     }
                                     i = i.wrapping_add(1);
@@ -1129,10 +1158,10 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                             )
                                                 -> ::core::ffi::c_int,
                                     ),
-                                    &mut s,
+                                    &raw mut s,
                                 );
                                 nlopt_unscale(n, s.scale, x, x);
-                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+                                j = 0 as ::core::ffi::c_uint;
                                 while j < n {
                                     if *x.offset(j as isize) < *lb.offset(j as isize) {
                                         *x.offset(j as isize) = *lb.offset(j as isize);
@@ -1205,8 +1234,8 @@ unsafe fn cobyla(
     let mut ia: ::core::ffi::c_int = 0;
     let mut idx: ::core::ffi::c_int = 0;
     let mut mpp: ::core::ffi::c_int = 0;
-    let mut _iact: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
-    let mut _w: *mut ::core::ffi::c_double = 0 as *mut ::core::ffi::c_double;
+    let mut _iact: *mut ::core::ffi::c_int = ::core::ptr::null_mut::<::core::ffi::c_int>();
+    let mut _w: *mut ::core::ffi::c_double = ::core::ptr::null_mut::<::core::ffi::c_double>();
     let mut rc: nlopt_result = 0 as nlopt_result;
     *(*stop).nevals_p = 0 as ::core::ffi::c_int;
     if n == 0 as ::core::ffi::c_int {

--- a/src/nlopt_cobyla.rs
+++ b/src/nlopt_cobyla.rs
@@ -26,10 +26,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::slice;
 
 pub(crate) fn nlopt_function_raw_callback<F: Func<T>, T>(
-    n: libc::c_uint,
+    n: ::core::ffi::c_uint,
     x: *const f64,
     _g: *mut f64,
-    params: *mut libc::c_void,
+    params: *mut ::core::ffi::c_void,
 ) -> f64 {
     // prepare args
     let argument = unsafe { slice::from_raw_parts(x, n as usize) };
@@ -48,10 +48,10 @@ pub(crate) fn nlopt_function_raw_callback<F: Func<T>, T>(
 }
 
 pub(crate) fn nlopt_constraint_raw_callback<F: Func<T>, T>(
-    n: libc::c_uint,
+    n: ::core::ffi::c_uint,
     x: *const f64,
     _g: *mut f64,
-    params: *mut libc::c_void,
+    params: *mut ::core::ffi::c_void,
 ) -> f64 {
     let f = unsafe { &mut *(params as *mut NLoptConstraintCfg<F, T>) };
     let argument = unsafe { slice::from_raw_parts(x, n as usize) };
@@ -98,38 +98,38 @@ fn fprintf(_io: Io, msg: &str) {
 //     pub type _IO_wide_data;
 //     pub type _IO_codecvt;
 //     pub type _IO_marker;
-//     fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
-//     fn realloc(_: *mut libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-//     fn free(__ptr: *mut libc::c_void);
+//     fn malloc(_: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
+//     fn realloc(_: *mut ::core::ffi::c_void, _: ::core::ffi::c_ulong) -> *mut ::core::ffi::c_void;
+//     fn free(__ptr: *mut ::core::ffi::c_void);
 //     fn abort() -> !;
 //     static mut stderr: *mut FILE;
-//     fn fprintf(_: *mut FILE, _: *const libc::c_char, _: ...) -> libc::c_int;
+//     fn fprintf(_: *mut FILE, _: *const ::core::ffi::c_char, _: ...) -> ::core::ffi::c_int;
 //     fn vsnprintf(
-//         _: *mut libc::c_char,
-//         _: libc::c_ulong,
-//         _: *const libc::c_char,
+//         _: *mut ::core::ffi::c_char,
+//         _: ::core::ffi::c_ulong,
+//         _: *const ::core::ffi::c_char,
 //         _: ::std::ffi::VaList,
-//     ) -> libc::c_int;
-//     fn sqrt(_: libc::c_double) -> libc::c_double;
-//     fn fabs(_: libc::c_double) -> libc::c_double;
-//     fn gettimeofday(__tv: *mut timeval, __tz: *mut libc::c_void) -> libc::c_int;
-//     fn strlen(_: *const libc::c_char) -> libc::c_ulong;
+//     ) -> ::core::ffi::c_int;
+//     fn sqrt(_: ::core::ffi::c_double) -> ::core::ffi::c_double;
+//     fn fabs(_: ::core::ffi::c_double) -> ::core::ffi::c_double;
+//     fn gettimeofday(__tv: *mut timeval, __tz: *mut ::core::ffi::c_void) -> ::core::ffi::c_int;
+//     fn strlen(_: *const ::core::ffi::c_char) -> ::core::ffi::c_ulong;
 // }
 type __builtin_va_list = [__va_list_tag; 1];
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct __va_list_tag {
-    pub gp_offset: libc::c_uint,
-    pub fp_offset: libc::c_uint,
-    pub overflow_arg_area: *mut libc::c_void,
-    pub reg_save_area: *mut libc::c_void,
+    pub gp_offset: ::core::ffi::c_uint,
+    pub fp_offset: ::core::ffi::c_uint,
+    pub overflow_arg_area: *mut ::core::ffi::c_void,
+    pub reg_save_area: *mut ::core::ffi::c_void,
 }
-type size_t = libc::c_ulong;
-type __uint32_t = libc::c_uint;
-type __off_t = libc::c_long;
-type __off64_t = libc::c_long;
-type __time_t = libc::c_long;
-type __suseconds_t = libc::c_long;
+type size_t = ::core::ffi::c_ulong;
+type __uint32_t = ::core::ffi::c_uint;
+type __off_t = ::core::ffi::c_long;
+type __off64_t = ::core::ffi::c_long;
+type __time_t = ::core::ffi::c_long;
+type __suseconds_t = ::core::ffi::c_long;
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct timeval {
@@ -140,67 +140,67 @@ type va_list = __builtin_va_list;
 // #[derive(Copy, Clone)]
 // #[repr(C)]
 // pub struct _IO_FILE {
-//     pub _flags: libc::c_int,
-//     pub _IO_read_ptr: *mut libc::c_char,
-//     pub _IO_read_end: *mut libc::c_char,
-//     pub _IO_read_base: *mut libc::c_char,
-//     pub _IO_write_base: *mut libc::c_char,
-//     pub _IO_write_ptr: *mut libc::c_char,
-//     pub _IO_write_end: *mut libc::c_char,
-//     pub _IO_buf_base: *mut libc::c_char,
-//     pub _IO_buf_end: *mut libc::c_char,
-//     pub _IO_save_base: *mut libc::c_char,
-//     pub _IO_backup_base: *mut libc::c_char,
-//     pub _IO_save_end: *mut libc::c_char,
+//     pub _flags: ::core::ffi::c_int,
+//     pub _IO_read_ptr: *mut ::core::ffi::c_char,
+//     pub _IO_read_end: *mut ::core::ffi::c_char,
+//     pub _IO_read_base: *mut ::core::ffi::c_char,
+//     pub _IO_write_base: *mut ::core::ffi::c_char,
+//     pub _IO_write_ptr: *mut ::core::ffi::c_char,
+//     pub _IO_write_end: *mut ::core::ffi::c_char,
+//     pub _IO_buf_base: *mut ::core::ffi::c_char,
+//     pub _IO_buf_end: *mut ::core::ffi::c_char,
+//     pub _IO_save_base: *mut ::core::ffi::c_char,
+//     pub _IO_backup_base: *mut ::core::ffi::c_char,
+//     pub _IO_save_end: *mut ::core::ffi::c_char,
 //     pub _markers: *mut _IO_marker,
 //     pub _chain: *mut _IO_FILE,
-//     pub _fileno: libc::c_int,
-//     pub _flags2: libc::c_int,
+//     pub _fileno: ::core::ffi::c_int,
+//     pub _flags2: ::core::ffi::c_int,
 //     pub _old_offset: __off_t,
-//     pub _cur_column: libc::c_ushort,
-//     pub _vtable_offset: libc::c_schar,
-//     pub _shortbuf: [libc::c_char; 1],
-//     pub _lock: *mut libc::c_void,
+//     pub _cur_column: ::core::ffi::c_ushort,
+//     pub _vtable_offset: ::core::ffi::c_schar,
+//     pub _shortbuf: [::core::ffi::c_char; 1],
+//     pub _lock: *mut ::core::ffi::c_void,
 //     pub _offset: __off64_t,
 //     pub _codecvt: *mut _IO_codecvt,
 //     pub _wide_data: *mut _IO_wide_data,
 //     pub _freeres_list: *mut _IO_FILE,
-//     pub _freeres_buf: *mut libc::c_void,
+//     pub _freeres_buf: *mut ::core::ffi::c_void,
 //     pub __pad5: size_t,
-//     pub _mode: libc::c_int,
-//     pub _unused2: [libc::c_char; 20],
+//     pub _mode: ::core::ffi::c_int,
+//     pub _unused2: [::core::ffi::c_char; 20],
 // }
 // pub type _IO_lock_t = ();
 // pub type FILE = _IO_FILE;
 
 type nlopt_func = Option<
     fn(
-        libc::c_uint,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
-    ) -> libc::c_double,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
+    ) -> ::core::ffi::c_double,
 >;
 type nlopt_mfunc = Option<
     unsafe fn(
-        libc::c_uint,
-        *mut libc::c_double,
-        libc::c_uint,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
+        ::core::ffi::c_uint,
+        *mut ::core::ffi::c_double,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
     ) -> (),
 >;
 type nlopt_precond = Option<
     unsafe fn(
-        libc::c_uint,
-        *const libc::c_double,
-        *const libc::c_double,
-        *mut libc::c_double,
-        *mut libc::c_void,
+        ::core::ffi::c_uint,
+        *const ::core::ffi::c_double,
+        *const ::core::ffi::c_double,
+        *mut ::core::ffi::c_double,
+        *mut ::core::ffi::c_void,
     ) -> (),
 >;
-type nlopt_result = libc::c_int;
+type nlopt_result = ::core::ffi::c_int;
 const NLOPT_NUM_RESULTS: nlopt_result = 7;
 const NLOPT_MAXTIME_REACHED: nlopt_result = 6;
 const NLOPT_MAXEVAL_REACHED: nlopt_result = 5;
@@ -217,90 +217,90 @@ const NLOPT_FAILURE: nlopt_result = -1;
 #[derive(Clone)]
 #[repr(C)]
 pub(crate) struct nlopt_stopping {
-    pub n: libc::c_uint,
-    pub minf_max: libc::c_double,
-    pub ftol_rel: libc::c_double,
-    pub ftol_abs: libc::c_double,
-    pub xtol_rel: libc::c_double,
-    pub xtol_abs: *const libc::c_double,
-    pub x_weights: *const libc::c_double,
-    pub nevals_p: *mut libc::c_int,
-    pub maxeval: libc::c_int,
-    pub maxtime: libc::c_double,
-    pub start: libc::c_double,
-    pub force_stop: *mut libc::c_int,
+    pub n: ::core::ffi::c_uint,
+    pub minf_max: ::core::ffi::c_double,
+    pub ftol_rel: ::core::ffi::c_double,
+    pub ftol_abs: ::core::ffi::c_double,
+    pub xtol_rel: ::core::ffi::c_double,
+    pub xtol_abs: *const ::core::ffi::c_double,
+    pub x_weights: *const ::core::ffi::c_double,
+    pub nevals_p: *mut ::core::ffi::c_int,
+    pub maxeval: ::core::ffi::c_int,
+    pub maxtime: ::core::ffi::c_double,
+    pub start: ::core::ffi::c_double,
+    pub force_stop: *mut ::core::ffi::c_int,
     pub stop_msg: String,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub(crate) struct nlopt_constraint {
-    pub m: libc::c_uint,
+    pub m: ::core::ffi::c_uint,
     pub f: nlopt_func,
     pub mf: nlopt_mfunc,
     pub pre: nlopt_precond,
-    pub f_data: *mut libc::c_void,
-    pub tol: *mut libc::c_double,
+    pub f_data: *mut ::core::ffi::c_void,
+    pub tol: *mut ::core::ffi::c_double,
 }
 #[derive(Copy, Clone)]
 #[repr(C)]
 struct func_wrap_state {
     pub f: nlopt_func,
-    pub f_data: *mut libc::c_void,
-    pub m_orig: libc::c_uint,
+    pub f_data: *mut ::core::ffi::c_void,
+    pub m_orig: ::core::ffi::c_uint,
     pub fc: *mut nlopt_constraint,
-    pub p: libc::c_uint,
+    pub p: ::core::ffi::c_uint,
     pub h: *mut nlopt_constraint,
-    pub xtmp: *mut libc::c_double,
-    pub lb: *mut libc::c_double,
-    pub ub: *mut libc::c_double,
-    pub con_tol: *mut libc::c_double,
-    pub scale: *mut libc::c_double,
+    pub xtmp: *mut ::core::ffi::c_double,
+    pub lb: *mut ::core::ffi::c_double,
+    pub ub: *mut ::core::ffi::c_double,
+    pub con_tol: *mut ::core::ffi::c_double,
+    pub scale: *mut ::core::ffi::c_double,
     pub stop: *mut nlopt_stopping,
 }
 const COBYLA_MSG_NONE: C2RustUnnamed = 0;
 type cobyla_function = unsafe fn(
-    libc::c_int,
-    libc::c_int,
-    *mut libc::c_double,
-    *mut libc::c_double,
-    *mut libc::c_double,
+    ::core::ffi::c_int,
+    ::core::ffi::c_int,
+    *mut ::core::ffi::c_double,
+    *mut ::core::ffi::c_double,
+    *mut ::core::ffi::c_double,
     *mut func_wrap_state,
-) -> libc::c_int;
+) -> ::core::ffi::c_int;
 type uint32_t = __uint32_t;
-type C2RustUnnamed = libc::c_uint;
+type C2RustUnnamed = ::core::ffi::c_uint;
 const COBYLA_MSG_INFO: C2RustUnnamed = 3;
 const COBYLA_MSG_ITER: C2RustUnnamed = 2;
 const COBYLA_MSG_EXIT: C2RustUnnamed = 1;
 
-unsafe fn nlopt_time_seed() -> libc::c_ulong {
-    // let mut tv = libc::timeval {
+unsafe fn nlopt_time_seed() -> ::core::ffi::c_ulong {
+    // let mut tv = ::core::ffi::timeval {
     //     tv_sec: 0,
     //     tv_usec: 0,
     // };
-    // libc::gettimeofday(&mut tv, 0 as *mut libc::timezone);
-    //return (tv.tv_sec ^ tv.tv_usec) as libc::c_ulong;
+    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
+    //return (tv.tv_sec ^ tv.tv_usec) as ::core::ffi::c_ulong;
     let start = SystemTime::now();
     let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time flies");
-    since_the_epoch.as_millis() as libc::c_ulong
+    since_the_epoch.as_millis() as ::core::ffi::c_ulong
 }
 
-unsafe fn nlopt_seconds() -> libc::c_double {
-    // static mut start_inited: libc::c_int = 0 as libc::c_int;
-    // static mut start: libc::timeval = libc::timeval {
+unsafe fn nlopt_seconds() -> ::core::ffi::c_double {
+    // static mut start_inited: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    // static mut start: ::core::ffi::timeval = ::core::ffi::timeval {
     //     tv_sec: 0,
     //     tv_usec: 0,
     // };
-    // let mut tv: libc::timeval = libc::timeval {
+    // let mut tv: ::core::ffi::timeval = ::core::ffi::timeval {
     //     tv_sec: 0,
     //     tv_usec: 0,
     // };
     // if start_inited == 0 {
-    //     start_inited = 1 as libc::c_int;
-    //     libc::gettimeofday(&mut start, 0 as *mut libc::timezone);
+    //     start_inited = 1 as ::core::ffi::c_int;
+    //     ::core::ffi::gettimeofday(&mut start, 0 as *mut ::core::ffi::timezone);
     // }
-    // libc::gettimeofday(&mut tv, 0 as *mut libc::timezone);
-    // return (tv.tv_sec - start.tv_sec) as libc::c_double
-    //     + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as libc::c_double;
+    // ::core::ffi::gettimeofday(&mut tv, 0 as *mut ::core::ffi::timezone);
+    // return (tv.tv_sec - start.tv_sec) as ::core::ffi::c_double
+    //     + 1.0e-6f64 * (tv.tv_usec - start.tv_usec) as ::core::ffi::c_double;
     static mut start_inited: bool = false;
     static mut start: SystemTime = UNIX_EPOCH;
     if !start_inited {
@@ -314,24 +314,24 @@ unsafe fn nlopt_seconds() -> libc::c_double {
         .as_secs_f64()
 }
 unsafe fn sc(
-    mut x: libc::c_double,
-    mut smin: libc::c_double,
-    mut smax: libc::c_double,
-) -> libc::c_double {
+    mut x: ::core::ffi::c_double,
+    mut smin: ::core::ffi::c_double,
+    mut smax: ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
     return smin + x * (smax - smin);
 }
 unsafe fn vector_norm(
-    mut n: libc::c_uint,
-    mut vec: *const libc::c_double,
-    mut w: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_double {
-    let mut i: libc::c_uint = 0;
-    let mut ret: libc::c_double = 0 as libc::c_int as libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut vec: *const ::core::ffi::c_double,
+    mut w: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * (sc(
@@ -343,7 +343,7 @@ unsafe fn vector_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
             while i < n {
                 ret += (sc(
                     *vec.offset(i as isize),
@@ -355,13 +355,13 @@ unsafe fn vector_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * (*vec.offset(i as isize)).abs();
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             ret += (*vec.offset(i as isize)).abs();
             i = i.wrapping_add(1);
@@ -370,18 +370,18 @@ unsafe fn vector_norm(
     return ret;
 }
 unsafe fn diff_norm(
-    mut n: libc::c_uint,
-    mut x: *const libc::c_double,
-    mut oldx: *const libc::c_double,
-    mut w: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_double {
-    let mut i: libc::c_uint = 0;
-    let mut ret: libc::c_double = 0 as libc::c_int as libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut x: *const ::core::ffi::c_double,
+    mut oldx: *const ::core::ffi::c_double,
+    mut w: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut ret: ::core::ffi::c_double = 0 as ::core::ffi::c_int as ::core::ffi::c_double;
     if !scale_min.is_null() && !scale_max.is_null() {
         if !w.is_null() {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
             while i < n {
                 ret += *w.offset(i as isize)
                     * (sc(
@@ -397,7 +397,7 @@ unsafe fn diff_norm(
                 i = i.wrapping_add(1);
             }
         } else {
-            i = 0 as libc::c_int as libc::c_uint;
+            i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
             while i < n {
                 ret += (sc(
                     *x.offset(i as isize),
@@ -413,13 +413,13 @@ unsafe fn diff_norm(
             }
         }
     } else if !w.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             ret += *w.offset(i as isize) * (*x.offset(i as isize) - *oldx.offset(i as isize)).abs();
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             ret += (*x.offset(i as isize) - *oldx.offset(i as isize)).abs();
             i = i.wrapping_add(1);
@@ -428,127 +428,127 @@ unsafe fn diff_norm(
     return ret;
 }
 unsafe fn relstop(
-    mut vold: libc::c_double,
-    mut vnew: libc::c_double,
-    mut reltol: libc::c_double,
-    mut abstol: libc::c_double,
-) -> libc::c_int {
+    mut vold: ::core::ffi::c_double,
+    mut vnew: ::core::ffi::c_double,
+    mut reltol: ::core::ffi::c_double,
+    mut abstol: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
     if nlopt_isinf(vold) != 0 {
-        return 0 as libc::c_int;
+        return 0 as ::core::ffi::c_int;
     }
     return ((vnew - vold).abs() < abstol
         || (vnew - vold).abs() < reltol * ((vnew).abs() + (vold)).abs() * 0.5f64
-        || reltol > 0 as libc::c_int as libc::c_double && vnew == vold) as libc::c_int;
+        || reltol > 0 as ::core::ffi::c_int as ::core::ffi::c_double && vnew == vold) as ::core::ffi::c_int;
 }
 
 unsafe fn nlopt_stop_ftol(
     mut s: *const nlopt_stopping,
-    mut f: libc::c_double,
-    mut oldf: libc::c_double,
-) -> libc::c_int {
+    mut f: ::core::ffi::c_double,
+    mut oldf: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
     return relstop(oldf, f, (*s).ftol_rel, (*s).ftol_abs);
 }
 
 unsafe fn nlopt_stop_f(
     mut s: *const nlopt_stopping,
-    mut f: libc::c_double,
-    mut oldf: libc::c_double,
-) -> libc::c_int {
-    return (f <= (*s).minf_max || nlopt_stop_ftol(s, f, oldf) != 0) as libc::c_int;
+    mut f: ::core::ffi::c_double,
+    mut oldf: ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    return (f <= (*s).minf_max || nlopt_stop_ftol(s, f, oldf) != 0) as ::core::ffi::c_int;
 }
 
 unsafe fn nlopt_stop_x(
     mut s: *const nlopt_stopping,
-    mut x: *const libc::c_double,
-    mut oldx: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut x: *const ::core::ffi::c_double,
+    mut oldx: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if diff_norm(
         (*s).n,
         x,
         oldx,
         (*s).x_weights,
-        0 as *const libc::c_double,
-        0 as *const libc::c_double,
+        0 as *const ::core::ffi::c_double,
+        0 as *const ::core::ffi::c_double,
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const libc::c_double,
-            0 as *const libc::c_double,
+            0 as *const ::core::ffi::c_double,
+            0 as *const ::core::ffi::c_double,
         )
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
     if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < (*s).n {
         if (*x.offset(i as isize) - *oldx.offset(i as isize)).abs()
             >= *((*s).xtol_abs).offset(i as isize)
         {
-            return 0 as libc::c_int;
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 
 unsafe fn nlopt_stop_dx(
     mut s: *const nlopt_stopping,
-    mut x: *const libc::c_double,
-    mut dx: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut x: *const ::core::ffi::c_double,
+    mut dx: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if vector_norm(
         (*s).n,
         dx,
         (*s).x_weights,
-        0 as *const libc::c_double,
-        0 as *const libc::c_double,
+        0 as *const ::core::ffi::c_double,
+        0 as *const ::core::ffi::c_double,
     ) < (*s).xtol_rel
         * vector_norm(
             (*s).n,
             x,
             (*s).x_weights,
-            0 as *const libc::c_double,
-            0 as *const libc::c_double,
+            0 as *const ::core::ffi::c_double,
+            0 as *const ::core::ffi::c_double,
         )
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
     if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < (*s).n {
         if (*dx.offset(i as isize)).abs() >= *((*s).xtol_abs).offset(i as isize) {
-            return 0 as libc::c_int;
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 
 unsafe fn nlopt_stop_xs(
     mut s: *const nlopt_stopping,
-    mut xs: *const libc::c_double,
-    mut oldxs: *const libc::c_double,
-    mut scale_min: *const libc::c_double,
-    mut scale_max: *const libc::c_double,
-) -> libc::c_int {
-    let mut i: libc::c_uint = 0;
+    mut xs: *const ::core::ffi::c_double,
+    mut oldxs: *const ::core::ffi::c_double,
+    mut scale_min: *const ::core::ffi::c_double,
+    mut scale_max: *const ::core::ffi::c_double,
+) -> ::core::ffi::c_int {
+    let mut i: ::core::ffi::c_uint = 0;
     if diff_norm((*s).n, xs, oldxs, (*s).x_weights, scale_min, scale_max)
         < (*s).xtol_rel * vector_norm((*s).n, xs, (*s).x_weights, scale_min, scale_max)
     {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
     if ((*s).xtol_abs).is_null() {
-        return 0 as libc::c_int;
+        return 0 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < (*s).n {
         if (sc(
             *xs.offset(i as isize),
@@ -562,81 +562,81 @@ unsafe fn nlopt_stop_xs(
         .abs()
             >= *((*s).xtol_abs).offset(i as isize)
         {
-            return 0 as libc::c_int;
+            return 0 as ::core::ffi::c_int;
         }
         i = i.wrapping_add(1);
     }
-    return 1 as libc::c_int;
+    return 1 as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_isinf(mut x: libc::c_double) -> libc::c_int {
+unsafe fn nlopt_isinf(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
     return ((x).abs() >= f64::INFINITY * 0.99f64
         || if x.is_infinite() {
             if x.is_sign_positive() { 1 } else { -1 }
         } else {
             0
-        } != 0) as libc::c_int;
+        } != 0) as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_isfinite(mut x: libc::c_double) -> libc::c_int {
-    return (x.abs() <= 1.7976931348623157e+308f64) as libc::c_int;
+unsafe fn nlopt_isfinite(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return (x.abs() <= 1.7976931348623157e+308f64) as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_istiny(mut x: libc::c_double) -> libc::c_int {
+unsafe fn nlopt_istiny(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
     if x == 0.0f64 {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     } else {
-        return (x.abs() < 2.2250738585072014e-308f64) as libc::c_int;
+        return (x.abs() < 2.2250738585072014e-308f64) as ::core::ffi::c_int;
     };
 }
 
-unsafe fn nlopt_isnan(mut x: libc::c_double) -> libc::c_int {
+unsafe fn nlopt_isnan(mut x: ::core::ffi::c_double) -> ::core::ffi::c_int {
     return x.is_nan() as i32;
 }
 
-unsafe fn nlopt_stop_evals(mut s: *const nlopt_stopping) -> libc::c_int {
-    return ((*s).maxeval > 0 as libc::c_int && *(*s).nevals_p >= (*s).maxeval) as libc::c_int;
+unsafe fn nlopt_stop_evals(mut s: *const nlopt_stopping) -> ::core::ffi::c_int {
+    return ((*s).maxeval > 0 as ::core::ffi::c_int && *(*s).nevals_p >= (*s).maxeval) as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_stop_time_(mut start: libc::c_double, mut maxtime: libc::c_double) -> libc::c_int {
-    return (maxtime > 0 as libc::c_int as libc::c_double && nlopt_seconds() - start >= maxtime)
-        as libc::c_int;
+unsafe fn nlopt_stop_time_(mut start: ::core::ffi::c_double, mut maxtime: ::core::ffi::c_double) -> ::core::ffi::c_int {
+    return (maxtime > 0 as ::core::ffi::c_int as ::core::ffi::c_double && nlopt_seconds() - start >= maxtime)
+        as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_stop_time(mut s: *const nlopt_stopping) -> libc::c_int {
+unsafe fn nlopt_stop_time(mut s: *const nlopt_stopping) -> ::core::ffi::c_int {
     return nlopt_stop_time_((*s).start, (*s).maxtime);
 }
 
-unsafe fn nlopt_stop_evalstime(mut stop: *const nlopt_stopping) -> libc::c_int {
-    return (nlopt_stop_evals(stop) != 0 || nlopt_stop_time(stop) != 0) as libc::c_int;
+unsafe fn nlopt_stop_evalstime(mut stop: *const nlopt_stopping) -> ::core::ffi::c_int {
+    return (nlopt_stop_evals(stop) != 0 || nlopt_stop_time(stop) != 0) as ::core::ffi::c_int;
 }
 
-unsafe fn nlopt_stop_forced(mut stop: *const nlopt_stopping) -> libc::c_int {
-    return (!((*stop).force_stop).is_null() && *(*stop).force_stop != 0) as libc::c_int;
+unsafe fn nlopt_stop_forced(mut stop: *const nlopt_stopping) -> ::core::ffi::c_int {
+    return (!((*stop).force_stop).is_null() && *(*stop).force_stop != 0) as ::core::ffi::c_int;
 }
 //
 // pub unsafe  fn nlopt_vsprintf(
-//     mut p: *mut libc::c_char,
-//     mut format: *const libc::c_char,
+//     mut p: *mut ::core::ffi::c_char,
+//     mut format: *const ::core::ffi::c_char,
 //     mut ap: ::std::ffi::VaList,
-// ) -> *mut libc::c_char {
-//     let mut len: size_t = (strlen(format)).wrapping_add(128 as libc::c_int as libc::c_ulong);
-//     let mut ret: libc::c_int = 0;
-//     p = realloc(p as *mut libc::c_void, len) as *mut libc::c_char;
+// ) -> *mut ::core::ffi::c_char {
+//     let mut len: size_t = (strlen(format)).wrapping_add(128 as ::core::ffi::c_int as ::core::ffi::c_ulong);
+//     let mut ret: ::core::ffi::c_int = 0;
+//     p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
 //     if p.is_null() {
 //         abort();
 //     }
 //     loop {
 //         ret = vsnprintf(p, len, format, ap.as_va_list());
-//         if !(ret < 0 as libc::c_int || ret as size_t >= len) {
+//         if !(ret < 0 as ::core::ffi::c_int || ret as size_t >= len) {
 //             break;
 //         }
-//         len = if ret >= 0 as libc::c_int {
-//             (ret + 1 as libc::c_int) as size_t
+//         len = if ret >= 0 as ::core::ffi::c_int {
+//             (ret + 1 as ::core::ffi::c_int) as size_t
 //         } else {
-//             len.wrapping_mul(3 as libc::c_int as libc::c_ulong) >> 1 as libc::c_int
+//             len.wrapping_mul(3 as ::core::ffi::c_int as ::core::ffi::c_ulong) >> 1 as ::core::ffi::c_int
 //         };
-//         p = realloc(p as *mut libc::c_void, len) as *mut libc::c_char;
+//         p = realloc(p as *mut ::core::ffi::c_void, len) as *mut ::core::ffi::c_char;
 //         if p.is_null() {
 //             abort();
 //         }
@@ -649,12 +649,12 @@ unsafe fn nlopt_stop_msg(mut s: *mut nlopt_stopping, msg: &str) {
 }
 
 unsafe fn nlopt_count_constraints(
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut c: *const nlopt_constraint,
-) -> libc::c_uint {
-    let mut i: libc::c_uint = 0;
-    let mut count: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    i = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_uint {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut count: ::core::ffi::c_uint = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < p {
         count = count.wrapping_add((*c.offset(i as isize)).m);
         i = i.wrapping_add(1);
@@ -663,12 +663,12 @@ unsafe fn nlopt_count_constraints(
 }
 
 unsafe fn nlopt_max_constraint_dim(
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut c: *const nlopt_constraint,
-) -> libc::c_uint {
-    let mut i: libc::c_uint = 0;
-    let mut max_dim: libc::c_uint = 0 as libc::c_int as libc::c_uint;
-    i = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_uint {
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut max_dim: ::core::ffi::c_uint = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < p {
         if (*c.offset(i as isize)).m > max_dim {
             max_dim = (*c.offset(i as isize)).m;
@@ -679,61 +679,61 @@ unsafe fn nlopt_max_constraint_dim(
 }
 
 unsafe fn nlopt_eval_constraint<U>(
-    mut result: *mut libc::c_double,
-    mut grad: *mut libc::c_double,
+    mut result: *mut ::core::ffi::c_double,
+    mut grad: *mut ::core::ffi::c_double,
     mut c: *const nlopt_constraint,
-    mut n: libc::c_uint,
-    mut x: *const libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut x: *const ::core::ffi::c_double,
 ) {
     if ((*c).f).is_some() {
-        *result.offset(0 as libc::c_int as isize) =
+        *result.offset(0 as ::core::ffi::c_int as isize) =
         // PATCH Weird bug ((*c).f).expect("non-null function pointer") calls the objective function!!!
         // even if (*c), nlopt_constraint object was correctly built with a nlopt_constraint_raw_callback!!! 
         //    ((*c).f).expect("non-null function pointer")(n, x, grad, (*c).f_data);
         // Maybe the U generic parameter required explains it cannot work like with C ???
         nlopt_constraint_raw_callback::<&dyn Func<U>, U>(n, x, grad, (*c).f_data);
         // relf: Take the opposite to manage cstr as being nonnegative in the end like the original cobyla
-        *result.offset(0 as libc::c_int as isize) = -*result.offset(0 as libc::c_int as isize)
+        *result.offset(0 as ::core::ffi::c_int as isize) = -*result.offset(0 as ::core::ffi::c_int as isize)
     } else {
         ((*c).mf).expect("non-null function pointer")((*c).m, result, n, x, grad, (*c).f_data);
     };
 }
 
 unsafe fn nlopt_compute_rescaling(
-    mut n: libc::c_uint,
-    mut dx: *const libc::c_double,
-) -> *mut libc::c_double {
-    // let mut s: *mut libc::c_double = malloc(
-    //     (::std::mem::size_of::<libc::c_double>() as libc::c_ulong).wrapping_mul(n as libc::c_ulong),
-    // ) as *mut libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut dx: *const ::core::ffi::c_double,
+) -> *mut ::core::ffi::c_double {
+    // let mut s: *mut ::core::ffi::c_double = malloc(
+    //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong).wrapping_mul(n as ::core::ffi::c_ulong),
+    // ) as *mut ::core::ffi::c_double;
 
-    let mut space: Box<Vec<libc::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
-    let s = space.as_mut_ptr() as *mut libc::c_double;
+    let mut space: Box<Vec<::core::ffi::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
+    let s = space.as_mut_ptr() as *mut ::core::ffi::c_double;
     std::mem::forget(space);
 
-    let mut i: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        return 0 as *mut libc::c_double;
+        return 0 as *mut ::core::ffi::c_double;
     }
-    i = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < n {
         *s.offset(i as isize) = 1.0f64;
         i = i.wrapping_add(1);
     }
-    if n == 1 as libc::c_int as libc::c_uint {
+    if n == 1 as ::core::ffi::c_int as ::core::ffi::c_uint {
         return s;
     }
-    i = 1 as libc::c_int as libc::c_uint;
+    i = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < n
         && *dx.offset(i as isize)
-            == *dx.offset(i.wrapping_sub(1 as libc::c_int as libc::c_uint) as isize)
+            == *dx.offset(i.wrapping_sub(1 as ::core::ffi::c_int as ::core::ffi::c_uint) as isize)
     {
         i = i.wrapping_add(1);
     }
     if i < n {
-        i = 1 as libc::c_int as libc::c_uint;
+        i = 1 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
-            *s.offset(i as isize) = *dx.offset(i as isize) / *dx.offset(0 as libc::c_int as isize);
+            *s.offset(i as isize) = *dx.offset(i as isize) / *dx.offset(0 as ::core::ffi::c_int as isize);
             i = i.wrapping_add(1);
         }
     }
@@ -741,20 +741,20 @@ unsafe fn nlopt_compute_rescaling(
 }
 
 unsafe fn nlopt_rescale(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-    mut xs: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+    mut xs: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) / *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -763,20 +763,20 @@ unsafe fn nlopt_rescale(
 }
 
 unsafe fn nlopt_unscale(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-    mut xs: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+    mut xs: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
     if s.is_null() {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize);
             i = i.wrapping_add(1);
         }
     } else {
-        i = 0 as libc::c_int as libc::c_uint;
+        i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while i < n {
             *xs.offset(i as isize) = *x.offset(i as isize) * *s.offset(i as isize);
             i = i.wrapping_add(1);
@@ -785,35 +785,35 @@ unsafe fn nlopt_unscale(
 }
 
 unsafe fn nlopt_new_rescaled(
-    mut n: libc::c_uint,
-    mut s: *const libc::c_double,
-    mut x: *const libc::c_double,
-) -> *mut libc::c_double {
-    // let mut xs: *mut libc::c_double = malloc(
-    //     (::std::mem::size_of::<libc::c_double>() as libc::c_ulong).wrapping_mul(n as libc::c_ulong),
-    // ) as *mut libc::c_double;
+    mut n: ::core::ffi::c_uint,
+    mut s: *const ::core::ffi::c_double,
+    mut x: *const ::core::ffi::c_double,
+) -> *mut ::core::ffi::c_double {
+    // let mut xs: *mut ::core::ffi::c_double = malloc(
+    //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong).wrapping_mul(n as ::core::ffi::c_ulong),
+    // ) as *mut ::core::ffi::c_double;
 
-    let mut space: Box<Vec<libc::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
-    let xs = space.as_mut_ptr() as *mut libc::c_double;
+    let mut space: Box<Vec<::core::ffi::c_double>> = Box::new(vec![0.; usize::try_from(n).unwrap()]);
+    let xs = space.as_mut_ptr() as *mut ::core::ffi::c_double;
     std::mem::forget(space);
 
     if xs.is_null() {
-        return 0 as *mut libc::c_double;
+        return 0 as *mut ::core::ffi::c_double;
     }
     nlopt_rescale(n, s, x, xs);
     return xs;
 }
 
 unsafe fn nlopt_reorder_bounds(
-    mut n: libc::c_uint,
-    mut lb: *mut libc::c_double,
-    mut ub: *mut libc::c_double,
+    mut n: ::core::ffi::c_uint,
+    mut lb: *mut ::core::ffi::c_double,
+    mut ub: *mut ::core::ffi::c_double,
 ) {
-    let mut i: libc::c_uint = 0;
-    i = 0 as libc::c_int as libc::c_uint;
+    let mut i: ::core::ffi::c_uint = 0;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while i < n {
         if *lb.offset(i as isize) > *ub.offset(i as isize) {
-            let mut t: libc::c_double = *lb.offset(i as isize);
+            let mut t: ::core::ffi::c_double = *lb.offset(i as isize);
             *lb.offset(i as isize) = *ub.offset(i as isize);
             *ub.offset(i as isize) = t;
         }
@@ -821,21 +821,21 @@ unsafe fn nlopt_reorder_bounds(
     }
 }
 unsafe fn func_wrap<U>(
-    mut ni: libc::c_int,
-    mut _mi: libc::c_int,
-    mut x: *mut libc::c_double,
-    mut f: *mut libc::c_double,
-    mut con: *mut libc::c_double,
+    mut ni: ::core::ffi::c_int,
+    mut _mi: ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut f: *mut ::core::ffi::c_double,
+    mut con: *mut ::core::ffi::c_double,
     mut s: *mut func_wrap_state,
-) -> libc::c_int {
-    let mut n: libc::c_uint = ni as libc::c_uint;
-    let mut i: libc::c_uint = 0;
-    let mut j: libc::c_uint = 0;
-    let mut k: libc::c_uint = 0;
-    let mut xtmp: *mut libc::c_double = (*s).xtmp;
-    let mut lb: *const libc::c_double = (*s).lb;
-    let mut ub: *const libc::c_double = (*s).ub;
-    j = 0 as libc::c_int as libc::c_uint;
+) -> ::core::ffi::c_int {
+    let mut n: ::core::ffi::c_uint = ni as ::core::ffi::c_uint;
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut j: ::core::ffi::c_uint = 0;
+    let mut k: ::core::ffi::c_uint = 0;
+    let mut xtmp: *mut ::core::ffi::c_double = (*s).xtmp;
+    let mut lb: *const ::core::ffi::c_double = (*s).lb;
+    let mut ub: *const ::core::ffi::c_double = (*s).ub;
+    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while j < n {
         if *x.offset(j as isize) < *lb.offset(j as isize) {
             *xtmp.offset(j as isize) = *lb.offset(j as isize);
@@ -850,26 +850,26 @@ unsafe fn func_wrap<U>(
     *f = ((*s).f).expect("non-null function pointer")(
         n,
         xtmp,
-        0 as *mut libc::c_double,
+        0 as *mut ::core::ffi::c_double,
         (*s).f_data,
     );
     if nlopt_stop_forced((*s).stop) != 0 {
-        return 1 as libc::c_int;
+        return 1 as ::core::ffi::c_int;
     }
-    i = 0 as libc::c_int as libc::c_uint;
-    j = 0 as libc::c_int as libc::c_uint;
+    i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
+    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while j < (*s).m_orig {
         nlopt_eval_constraint::<U>(
             con.offset(i as isize),
-            0 as *mut libc::c_double,
+            0 as *mut ::core::ffi::c_double,
             ((*s).fc).offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
-            return 1 as libc::c_int;
+            return 1 as ::core::ffi::c_int;
         }
-        k = 0 as libc::c_int as libc::c_uint;
+        k = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while k < (*((*s).fc).offset(j as isize)).m {
             *con.offset(i.wrapping_add(k) as isize) = -*con.offset(i.wrapping_add(k) as isize);
             k = k.wrapping_add(1);
@@ -877,19 +877,19 @@ unsafe fn func_wrap<U>(
         i = i.wrapping_add((*((*s).fc).offset(j as isize)).m);
         j = j.wrapping_add(1);
     }
-    j = 0 as libc::c_int as libc::c_uint;
+    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while j < (*s).p {
         nlopt_eval_constraint::<U>(
             con.offset(i as isize),
-            0 as *mut libc::c_double,
+            0 as *mut ::core::ffi::c_double,
             ((*s).h).offset(j as isize),
             n,
             xtmp,
         );
         if nlopt_stop_forced((*s).stop) != 0 {
-            return 1 as libc::c_int;
+            return 1 as ::core::ffi::c_int;
         }
-        k = 0 as libc::c_int as libc::c_uint;
+        k = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         while k < (*((*s).h).offset(j as isize)).m {
             *con.offset(
                 i.wrapping_add((*((*s).h).offset(j as isize)).m)
@@ -898,11 +898,11 @@ unsafe fn func_wrap<U>(
             k = k.wrapping_add(1);
         }
         i = i.wrapping_add(
-            (2 as libc::c_int as libc::c_uint).wrapping_mul((*((*s).h).offset(j as isize)).m),
+            (2 as ::core::ffi::c_int as ::core::ffi::c_uint).wrapping_mul((*((*s).h).offset(j as isize)).m),
         );
         j = j.wrapping_add(1);
     }
-    j = 0 as libc::c_int as libc::c_uint;
+    j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
     while j < n {
         if nlopt_isinf(*lb.offset(j as isize)) == 0 {
             let fresh1 = i;
@@ -916,43 +916,43 @@ unsafe fn func_wrap<U>(
         }
         j = j.wrapping_add(1);
     }
-    return 0 as libc::c_int;
+    return 0 as ::core::ffi::c_int;
 }
 pub(crate) unsafe fn cobyla_minimize<U>(
-    mut n: libc::c_uint,
+    mut n: ::core::ffi::c_uint,
     mut f: nlopt_func,
-    mut f_data: *mut libc::c_void,
-    mut m: libc::c_uint,
+    mut f_data: *mut ::core::ffi::c_void,
+    mut m: ::core::ffi::c_uint,
     mut fc: *mut nlopt_constraint,
-    mut p: libc::c_uint,
+    mut p: ::core::ffi::c_uint,
     mut h: *mut nlopt_constraint,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut dx: *const libc::c_double,
+    mut dx: *const ::core::ffi::c_double,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut i: libc::c_uint = 0;
-    let mut j: libc::c_uint = 0;
+    let mut i: ::core::ffi::c_uint = 0;
+    let mut j: ::core::ffi::c_uint = 0;
     let mut s: func_wrap_state = func_wrap_state {
         f: None,
-        f_data: 0 as *mut libc::c_void,
+        f_data: 0 as *mut ::core::ffi::c_void,
         m_orig: 0,
         fc: 0 as *mut nlopt_constraint,
         p: 0,
         h: 0 as *mut nlopt_constraint,
-        xtmp: 0 as *mut libc::c_double,
-        lb: 0 as *mut libc::c_double,
-        ub: 0 as *mut libc::c_double,
-        con_tol: 0 as *mut libc::c_double,
-        scale: 0 as *mut libc::c_double,
+        xtmp: 0 as *mut ::core::ffi::c_double,
+        lb: 0 as *mut ::core::ffi::c_double,
+        ub: 0 as *mut ::core::ffi::c_double,
+        con_tol: 0 as *mut ::core::ffi::c_double,
+        scale: 0 as *mut ::core::ffi::c_double,
         stop: 0 as *mut nlopt_stopping,
     };
     let mut ret: nlopt_result = 0 as nlopt_result;
-    let mut rhobeg: libc::c_double = 0.;
-    let mut rhoend: libc::c_double = 0.;
+    let mut rhobeg: ::core::ffi::c_double = 0.;
+    let mut rhoend: ::core::ffi::c_double = 0.;
     s.f = f;
     s.f_data = f_data;
     s.m_orig = m;
@@ -960,7 +960,7 @@ pub(crate) unsafe fn cobyla_minimize<U>(
     s.p = p;
     s.h = h;
     s.stop = stop;
-    s.scale = 0 as *mut libc::c_double;
+    s.scale = 0 as *mut ::core::ffi::c_double;
     s.con_tol = s.scale;
     s.xtmp = s.con_tol;
     s.ub = s.xtmp;
@@ -969,13 +969,13 @@ pub(crate) unsafe fn cobyla_minimize<U>(
     if (s.scale).is_null() {
         ret = NLOPT_OUT_OF_MEMORY;
     } else {
-        j = 0 as libc::c_int as libc::c_uint;
+        j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
         loop {
             if !(j < n) {
                 current_block = 15652330335145281839;
                 break;
             }
-            if *(s.scale).offset(j as isize) == 0 as libc::c_int as libc::c_double
+            if *(s.scale).offset(j as isize) == 0 as ::core::ffi::c_int as ::core::ffi::c_double
                 || nlopt_isfinite(*(s.scale).offset(j as isize)) == 0
             {
                 nlopt_stop_msg(
@@ -1006,24 +1006,24 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                     } else {
                         nlopt_reorder_bounds(n, s.lb, s.ub);
                         // s.xtmp = malloc(
-                        //     (::std::mem::size_of::<libc::c_double>() as libc::c_ulong)
-                        //         .wrapping_mul(n as libc::c_ulong),
-                        // ) as *mut libc::c_double;
+                        //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong)
+                        //         .wrapping_mul(n as ::core::ffi::c_ulong),
+                        // ) as *mut ::core::ffi::c_double;
 
-                        let mut space: Box<Vec<libc::c_double>> =
+                        let mut space: Box<Vec<::core::ffi::c_double>> =
                             Box::new(vec![0.; usize::try_from(n).unwrap()]);
-                        s.xtmp = space.as_mut_ptr() as *mut libc::c_double;
+                        s.xtmp = space.as_mut_ptr() as *mut ::core::ffi::c_double;
                         std::mem::forget(space);
 
                         if (s.xtmp).is_null() {
                             ret = NLOPT_OUT_OF_MEMORY;
                         } else {
-                            rhobeg = (*dx.offset(0 as libc::c_int as isize)
-                                / *(s.scale).offset(0 as libc::c_int as isize))
+                            rhobeg = (*dx.offset(0 as ::core::ffi::c_int as isize)
+                                / *(s.scale).offset(0 as ::core::ffi::c_int as isize))
                             .abs();
                             rhoend = (*stop).xtol_rel * rhobeg;
                             if !((*stop).xtol_abs).is_null() {
-                                j = 0 as libc::c_int as libc::c_uint;
+                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                                 while j < n {
                                     if rhoend
                                         < *((*stop).xtol_abs).offset(j as isize)
@@ -1036,10 +1036,10 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                 }
                             }
                             m = (nlopt_count_constraints(m, fc)).wrapping_add(
-                                (2 as libc::c_int as libc::c_uint)
+                                (2 as ::core::ffi::c_int as ::core::ffi::c_uint)
                                     .wrapping_mul(nlopt_count_constraints(p, h)),
                             );
-                            j = 0 as libc::c_int as libc::c_uint;
+                            j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                             while j < n {
                                 if nlopt_isinf(*lb.offset(j as isize)) == 0 {
                                     m = m.wrapping_add(1);
@@ -1050,31 +1050,31 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                 j = j.wrapping_add(1);
                             }
                             // s.con_tol = malloc(
-                            //     (::std::mem::size_of::<libc::c_double>() as libc::c_ulong)
-                            //         .wrapping_mul(m as libc::c_ulong),
-                            // ) as *mut libc::c_double;
+                            //     (::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong)
+                            //         .wrapping_mul(m as ::core::ffi::c_ulong),
+                            // ) as *mut ::core::ffi::c_double;
 
                             if m > 0 {
-                                let mut space: Box<Vec<libc::c_double>> =
+                                let mut space: Box<Vec<::core::ffi::c_double>> =
                                     Box::new(vec![0.; usize::try_from(m).unwrap()]);
-                                s.con_tol = space.as_mut_ptr() as *mut libc::c_double;
+                                s.con_tol = space.as_mut_ptr() as *mut ::core::ffi::c_double;
                                 std::mem::forget(space);
                             }
 
                             if m != 0 && (s.con_tol).is_null() {
                                 ret = NLOPT_OUT_OF_MEMORY;
                             } else {
-                                j = 0 as libc::c_int as libc::c_uint;
+                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                                 while j < m {
                                     *(s.con_tol).offset(j as isize) =
-                                        0 as libc::c_int as libc::c_double;
+                                        0 as ::core::ffi::c_int as ::core::ffi::c_double;
                                     j = j.wrapping_add(1);
                                 }
-                                i = 0 as libc::c_int as libc::c_uint;
+                                i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                                 j = i;
                                 while i < s.m_orig {
-                                    let mut ji: libc::c_uint = j;
-                                    let mut jnext: libc::c_uint =
+                                    let mut ji: ::core::ffi::c_uint = j;
+                                    let mut jnext: ::core::ffi::c_uint =
                                         j.wrapping_add((*fc.offset(i as isize)).m);
                                     while j < jnext {
                                         *(s.con_tol).offset(j as isize) =
@@ -1084,10 +1084,10 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                     }
                                     i = i.wrapping_add(1);
                                 }
-                                i = 0 as libc::c_int as libc::c_uint;
+                                i = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                                 while i < s.p {
-                                    let mut ji_0: libc::c_uint = j;
-                                    let mut jnext_0: libc::c_uint =
+                                    let mut ji_0: ::core::ffi::c_uint = j;
+                                    let mut jnext_0: ::core::ffi::c_uint =
                                         j.wrapping_add((*h.offset(i as isize)).m);
                                     while j < jnext_0 {
                                         *(s.con_tol).offset(j as isize) =
@@ -1107,8 +1107,8 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                 }
                                 nlopt_rescale(n, s.scale, x, x);
                                 ret = cobyla(
-                                    n as libc::c_int,
-                                    m as libc::c_int,
+                                    n as ::core::ffi::c_int,
+                                    m as ::core::ffi::c_int,
                                     x,
                                     minf,
                                     rhobeg,
@@ -1116,23 +1116,23 @@ pub(crate) unsafe fn cobyla_minimize<U>(
                                     stop,
                                     s.lb,
                                     s.ub,
-                                    COBYLA_MSG_NONE as libc::c_int,
+                                    COBYLA_MSG_NONE as ::core::ffi::c_int,
                                     Some(
                                         func_wrap::<U>
                                             as unsafe fn(
-                                                libc::c_int,
-                                                libc::c_int,
-                                                *mut libc::c_double,
-                                                *mut libc::c_double,
-                                                *mut libc::c_double,
+                                                ::core::ffi::c_int,
+                                                ::core::ffi::c_int,
+                                                *mut ::core::ffi::c_double,
+                                                *mut ::core::ffi::c_double,
+                                                *mut ::core::ffi::c_double,
                                                 *mut func_wrap_state,
                                             )
-                                                -> libc::c_int,
+                                                -> ::core::ffi::c_int,
                                     ),
                                     &mut s,
                                 );
                                 nlopt_unscale(n, s.scale, x, x);
-                                j = 0 as libc::c_int as libc::c_uint;
+                                j = 0 as ::core::ffi::c_int as ::core::ffi::c_uint;
                                 while j < n {
                                     if *x.offset(j as isize) < *lb.offset(j as isize) {
                                         *x.offset(j as isize) = *lb.offset(j as isize);
@@ -1149,11 +1149,11 @@ pub(crate) unsafe fn cobyla_minimize<U>(
             }
         }
     }
-    // free(s.con_tol as *mut libc::c_void);
-    // free(s.xtmp as *mut libc::c_void);
-    // free(s.ub as *mut libc::c_void);
-    // free(s.lb as *mut libc::c_void);
-    // free(s.scale as *mut libc::c_void);
+    // free(s.con_tol as *mut ::core::ffi::c_void);
+    // free(s.xtmp as *mut ::core::ffi::c_void);
+    // free(s.ub as *mut ::core::ffi::c_void);
+    // free(s.lb as *mut ::core::ffi::c_void);
+    // free(s.scale as *mut ::core::ffi::c_void);
 
     if m > 0 {
         let _ = Box::from_raw(s.con_tol);
@@ -1167,97 +1167,97 @@ pub(crate) unsafe fn cobyla_minimize<U>(
 }
 unsafe fn lcg_rand(mut seed: *mut uint32_t) -> uint32_t {
     *seed = (*seed)
-        .wrapping_mul(1103515245 as libc::c_int as libc::c_uint)
-        .wrapping_add(12345 as libc::c_int as libc::c_uint);
+        .wrapping_mul(1103515245 as ::core::ffi::c_int as ::core::ffi::c_uint)
+        .wrapping_add(12345 as ::core::ffi::c_int as ::core::ffi::c_uint);
     return *seed;
 }
 unsafe fn lcg_urand(
     mut seed: *mut uint32_t,
-    mut a: libc::c_double,
-    mut b: libc::c_double,
-) -> libc::c_double {
-    return a + lcg_rand(seed) as libc::c_double * (b - a)
-        / -(1 as libc::c_int) as uint32_t as libc::c_double;
+    mut a: ::core::ffi::c_double,
+    mut b: ::core::ffi::c_double,
+) -> ::core::ffi::c_double {
+    return a + lcg_rand(seed) as ::core::ffi::c_double * (b - a)
+        / -(1 as ::core::ffi::c_int) as uint32_t as ::core::ffi::c_double;
 }
 
 unsafe fn cobyla(
-    mut n: libc::c_int,
-    mut m: libc::c_int,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
-    mut rhobeg: libc::c_double,
-    mut rhoend: libc::c_double,
+    mut n: ::core::ffi::c_int,
+    mut m: ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
+    mut rhobeg: ::core::ffi::c_double,
+    mut rhoend: ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut iprint: libc::c_int,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut iprint: ::core::ffi::c_int,
     mut calcfc: Option<cobyla_function>,
     mut state: *mut func_wrap_state,
 ) -> nlopt_result {
-    let mut icon: libc::c_int = 0;
-    let mut isim: libc::c_int = 0;
-    let mut isigb: libc::c_int = 0;
-    let mut idatm: libc::c_int = 0;
-    let mut iveta: libc::c_int = 0;
-    let mut isimi: libc::c_int = 0;
-    let mut ivsig: libc::c_int = 0;
-    let mut iwork: libc::c_int = 0;
-    let mut ia: libc::c_int = 0;
-    let mut idx: libc::c_int = 0;
-    let mut mpp: libc::c_int = 0;
-    let mut _iact: *mut libc::c_int = 0 as *mut libc::c_int;
-    let mut _w: *mut libc::c_double = 0 as *mut libc::c_double;
+    let mut icon: ::core::ffi::c_int = 0;
+    let mut isim: ::core::ffi::c_int = 0;
+    let mut isigb: ::core::ffi::c_int = 0;
+    let mut idatm: ::core::ffi::c_int = 0;
+    let mut iveta: ::core::ffi::c_int = 0;
+    let mut isimi: ::core::ffi::c_int = 0;
+    let mut ivsig: ::core::ffi::c_int = 0;
+    let mut iwork: ::core::ffi::c_int = 0;
+    let mut ia: ::core::ffi::c_int = 0;
+    let mut idx: ::core::ffi::c_int = 0;
+    let mut mpp: ::core::ffi::c_int = 0;
+    let mut _iact: *mut ::core::ffi::c_int = 0 as *mut ::core::ffi::c_int;
+    let mut _w: *mut ::core::ffi::c_double = 0 as *mut ::core::ffi::c_double;
     let mut rc: nlopt_result = 0 as nlopt_result;
-    *(*stop).nevals_p = 0 as libc::c_int;
-    if n == 0 as libc::c_int {
-        if iprint >= 1 as libc::c_int {
+    *(*stop).nevals_p = 0 as ::core::ffi::c_int;
+    if n == 0 as ::core::ffi::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(Io::stderr, "cobyla: N==0.");
         }
         return NLOPT_SUCCESS;
     }
-    if n < 0 as libc::c_int || m < 0 as libc::c_int {
-        if iprint >= 1 as libc::c_int {
+    if n < 0 as ::core::ffi::c_int || m < 0 as ::core::ffi::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(Io::stderr, "cobyla: N<0 or M<0.");
         }
         return NLOPT_INVALID_ARGS;
     }
     // w = malloc(
-    //     ((n * (3 as libc::c_int * n + 2 as libc::c_int * m + 11 as libc::c_int)
-    //         + 4 as libc::c_int * m
-    //         + 6 as libc::c_int) as libc::c_uint as libc::c_ulong)
-    //         .wrapping_mul(::std::mem::size_of::<libc::c_double>() as libc::c_ulong),
-    // ) as *mut libc::c_double;
+    //     ((n * (3 as ::core::ffi::c_int * n + 2 as ::core::ffi::c_int * m + 11 as ::core::ffi::c_int)
+    //         + 4 as ::core::ffi::c_int * m
+    //         + 6 as ::core::ffi::c_int) as ::core::ffi::c_uint as ::core::ffi::c_ulong)
+    //         .wrapping_mul(::std::mem::size_of::<::core::ffi::c_double>() as ::core::ffi::c_ulong),
+    // ) as *mut ::core::ffi::c_double;
 
-    let space_size = n * (3 as libc::c_int * n + 2 as libc::c_int * m + 11 as libc::c_int)
-        + 4 as libc::c_int * m
-        + 6 as libc::c_int;
-    let mut space: Box<Vec<libc::c_double>> =
+    let space_size = n * (3 as ::core::ffi::c_int * n + 2 as ::core::ffi::c_int * m + 11 as ::core::ffi::c_int)
+        + 4 as ::core::ffi::c_int * m
+        + 6 as ::core::ffi::c_int;
+    let mut space: Box<Vec<::core::ffi::c_double>> =
         Box::new(vec![0.; usize::try_from(space_size).unwrap()]);
-    let mut w = space.as_mut_ptr() as *mut libc::c_double;
+    let mut w = space.as_mut_ptr() as *mut ::core::ffi::c_double;
     std::mem::forget(space);
 
     if w.is_null() {
-        if iprint >= 1 as libc::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(Io::stderr, "cobyla: memory allocation error");
         }
         return NLOPT_OUT_OF_MEMORY;
     }
     // iact = malloc(
-    //     ((m + 1 as libc::c_int) as libc::c_uint as libc::c_ulong)
-    //         .wrapping_mul(::std::mem::size_of::<libc::c_int>() as libc::c_ulong),
-    // ) as *mut libc::c_int;
+    //     ((m + 1 as ::core::ffi::c_int) as ::core::ffi::c_uint as ::core::ffi::c_ulong)
+    //         .wrapping_mul(::std::mem::size_of::<::core::ffi::c_int>() as ::core::ffi::c_ulong),
+    // ) as *mut ::core::ffi::c_int;
 
     let space_size = m + 1;
-    let mut space: Box<Vec<libc::c_double>> =
+    let mut space: Box<Vec<::core::ffi::c_double>> =
         Box::new(vec![0.; usize::try_from(space_size).unwrap()]);
-    let mut iact = space.as_mut_ptr() as *mut libc::c_int;
+    let mut iact = space.as_mut_ptr() as *mut ::core::ffi::c_int;
     std::mem::forget(space);
 
     if iact.is_null() {
-        if iprint >= 1 as libc::c_int {
+        if iprint >= 1 as ::core::ffi::c_int {
             fprintf(Io::stderr, "cobyla: memory allocation error.");
         }
-        //free(w as *mut libc::c_void);
+        //free(w as *mut ::core::ffi::c_void);
         let _ = Box::from_raw(w);
         return NLOPT_OUT_OF_MEMORY;
     }
@@ -1266,8 +1266,8 @@ unsafe fn cobyla(
     x = x.offset(-1);
     lb = lb.offset(-1);
     ub = ub.offset(-1);
-    mpp = m + 2 as libc::c_int;
-    icon = 1 as libc::c_int;
+    mpp = m + 2 as ::core::ffi::c_int;
+    icon = 1 as ::core::ffi::c_int;
     isim = icon + mpp;
     isimi = isim + n * n + n;
     idatm = isimi + n * n;
@@ -1281,13 +1281,13 @@ unsafe fn cobyla(
         &mut n,
         &mut m,
         &mut mpp,
-        &mut *x.offset(1 as libc::c_int as isize),
+        &mut *x.offset(1 as ::core::ffi::c_int as isize),
         minf,
         &mut rhobeg,
         rhoend,
         stop,
-        &*lb.offset(1 as libc::c_int as isize),
-        &*ub.offset(1 as libc::c_int as isize),
+        &*lb.offset(1 as ::core::ffi::c_int as isize),
+        &*ub.offset(1 as ::core::ffi::c_int as isize),
         &mut iprint,
         &mut *w.offset(icon as isize),
         &mut *w.offset(isim as isize),
@@ -1299,125 +1299,125 @@ unsafe fn cobyla(
         &mut *w.offset(isigb as isize),
         &mut *w.offset(idx as isize),
         &mut *w.offset(iwork as isize),
-        &mut *iact.offset(1 as libc::c_int as isize),
+        &mut *iact.offset(1 as ::core::ffi::c_int as isize),
         calcfc,
         state,
     );
     iact = iact.offset(1);
     w = w.offset(1);
-    // free(w as *mut libc::c_void);
-    // free(iact as *mut libc::c_void);
+    // free(w as *mut ::core::ffi::c_void);
+    // free(iact as *mut ::core::ffi::c_void);
     let _ = Box::from_raw(w);
     let _ = Box::from_raw(iact);
     return rc;
 }
 unsafe fn cobylb(
-    mut n: *mut libc::c_int,
-    mut m: *mut libc::c_int,
-    mut mpp: *mut libc::c_int,
-    mut x: *mut libc::c_double,
-    mut minf: *mut libc::c_double,
-    mut rhobeg: *mut libc::c_double,
-    mut rhoend: libc::c_double,
+    mut n: *mut ::core::ffi::c_int,
+    mut m: *mut ::core::ffi::c_int,
+    mut mpp: *mut ::core::ffi::c_int,
+    mut x: *mut ::core::ffi::c_double,
+    mut minf: *mut ::core::ffi::c_double,
+    mut rhobeg: *mut ::core::ffi::c_double,
+    mut rhoend: ::core::ffi::c_double,
     mut stop: *mut nlopt_stopping,
-    mut lb: *const libc::c_double,
-    mut ub: *const libc::c_double,
-    mut iprint: *mut libc::c_int,
-    mut con: *mut libc::c_double,
-    mut sim: *mut libc::c_double,
-    mut simi: *mut libc::c_double,
-    mut datmat: *mut libc::c_double,
-    mut a: *mut libc::c_double,
-    mut vsig: *mut libc::c_double,
-    mut veta: *mut libc::c_double,
-    mut sigbar: *mut libc::c_double,
-    mut dx: *mut libc::c_double,
-    mut w: *mut libc::c_double,
-    mut iact: *mut libc::c_int,
+    mut lb: *const ::core::ffi::c_double,
+    mut ub: *const ::core::ffi::c_double,
+    mut iprint: *mut ::core::ffi::c_int,
+    mut con: *mut ::core::ffi::c_double,
+    mut sim: *mut ::core::ffi::c_double,
+    mut simi: *mut ::core::ffi::c_double,
+    mut datmat: *mut ::core::ffi::c_double,
+    mut a: *mut ::core::ffi::c_double,
+    mut vsig: *mut ::core::ffi::c_double,
+    mut veta: *mut ::core::ffi::c_double,
+    mut sigbar: *mut ::core::ffi::c_double,
+    mut dx: *mut ::core::ffi::c_double,
+    mut w: *mut ::core::ffi::c_double,
+    mut iact: *mut ::core::ffi::c_int,
     mut calcfc: Option<cobyla_function>,
     mut state: *mut func_wrap_state,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut sim_dim1: libc::c_int = 0;
-    let mut sim_offset: libc::c_int = 0;
-    let mut simi_dim1: libc::c_int = 0;
-    let mut simi_offset: libc::c_int = 0;
-    let mut datmat_dim1: libc::c_int = 0;
-    let mut datmat_offset: libc::c_int = 0;
-    let mut a_dim1: libc::c_int = 0;
-    let mut a_offset: libc::c_int = 0;
-    let mut i__1: libc::c_int = 0;
-    let mut i__2: libc::c_int = 0;
-    let mut i__3: libc::c_int = 0;
-    let mut d__1: libc::c_double = 0.;
-    let mut d__2: libc::c_double = 0.;
-    let mut alpha: libc::c_double = 0.;
-    let mut delta: libc::c_double = 0.;
-    let mut denom: libc::c_double = 0.;
-    let mut tempa: libc::c_double = 0.;
-    let mut barmu: libc::c_double = 0.;
-    let mut beta: libc::c_double = 0.;
-    let mut cmin: libc::c_double = 0.0f64;
-    let mut cmax: libc::c_double = 0.0f64;
-    let mut cvmaxm: libc::c_double = 0.;
-    let mut dxsign: libc::c_double = 0.;
-    let mut prerem: libc::c_double = 0.0f64;
-    let mut edgmax: libc::c_double = 0.;
-    let mut pareta: libc::c_double = 0.;
-    let mut prerec: libc::c_double = 0.0f64;
-    let mut phimin: libc::c_double = 0.;
-    let mut parsig: libc::c_double = 0.0f64;
-    let mut gamma_: libc::c_double = 0.;
-    let mut phi: libc::c_double = 0.;
-    let mut rho: libc::c_double = 0.;
-    let mut sum: libc::c_double = 0.0f64;
-    let mut ratio: libc::c_double = 0.;
-    let mut vmold: libc::c_double = 0.;
-    let mut parmu: libc::c_double = 0.;
-    let mut error: libc::c_double = 0.;
-    let mut vmnew: libc::c_double = 0.;
-    let mut resmax: libc::c_double = 0.;
-    let mut cvmaxp: libc::c_double = 0.;
-    let mut resnew: libc::c_double = 0.;
-    let mut trured: libc::c_double = 0.;
-    let mut temp: libc::c_double = 0.;
-    let mut wsig: libc::c_double = 0.;
-    let mut f: libc::c_double = 0.;
-    let mut weta: libc::c_double = 0.;
-    let mut i__: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut l: libc::c_int = 0;
-    let mut idxnew: libc::c_int = 0;
-    let mut iflag: libc::c_int = 0 as libc::c_int;
-    let mut iptemp: libc::c_int = 0;
-    let mut isdirn: libc::c_int = 0;
-    let mut izdota: libc::c_int = 0;
-    let mut ivmc: libc::c_int = 0;
-    let mut ivmd: libc::c_int = 0;
-    let mut mp: libc::c_int = 0;
-    let mut np: libc::c_int = 0;
-    let mut iz: libc::c_int = 0;
-    let mut ibrnch: libc::c_int = 0;
-    let mut nbest: libc::c_int = 0;
-    let mut ifull: libc::c_int = 0 as libc::c_int;
-    let mut iptem: libc::c_int = 0;
-    let mut jdrop: libc::c_int = 0;
+    let mut sim_dim1: ::core::ffi::c_int = 0;
+    let mut sim_offset: ::core::ffi::c_int = 0;
+    let mut simi_dim1: ::core::ffi::c_int = 0;
+    let mut simi_offset: ::core::ffi::c_int = 0;
+    let mut datmat_dim1: ::core::ffi::c_int = 0;
+    let mut datmat_offset: ::core::ffi::c_int = 0;
+    let mut a_dim1: ::core::ffi::c_int = 0;
+    let mut a_offset: ::core::ffi::c_int = 0;
+    let mut i__1: ::core::ffi::c_int = 0;
+    let mut i__2: ::core::ffi::c_int = 0;
+    let mut i__3: ::core::ffi::c_int = 0;
+    let mut d__1: ::core::ffi::c_double = 0.;
+    let mut d__2: ::core::ffi::c_double = 0.;
+    let mut alpha: ::core::ffi::c_double = 0.;
+    let mut delta: ::core::ffi::c_double = 0.;
+    let mut denom: ::core::ffi::c_double = 0.;
+    let mut tempa: ::core::ffi::c_double = 0.;
+    let mut barmu: ::core::ffi::c_double = 0.;
+    let mut beta: ::core::ffi::c_double = 0.;
+    let mut cmin: ::core::ffi::c_double = 0.0f64;
+    let mut cmax: ::core::ffi::c_double = 0.0f64;
+    let mut cvmaxm: ::core::ffi::c_double = 0.;
+    let mut dxsign: ::core::ffi::c_double = 0.;
+    let mut prerem: ::core::ffi::c_double = 0.0f64;
+    let mut edgmax: ::core::ffi::c_double = 0.;
+    let mut pareta: ::core::ffi::c_double = 0.;
+    let mut prerec: ::core::ffi::c_double = 0.0f64;
+    let mut phimin: ::core::ffi::c_double = 0.;
+    let mut parsig: ::core::ffi::c_double = 0.0f64;
+    let mut gamma_: ::core::ffi::c_double = 0.;
+    let mut phi: ::core::ffi::c_double = 0.;
+    let mut rho: ::core::ffi::c_double = 0.;
+    let mut sum: ::core::ffi::c_double = 0.0f64;
+    let mut ratio: ::core::ffi::c_double = 0.;
+    let mut vmold: ::core::ffi::c_double = 0.;
+    let mut parmu: ::core::ffi::c_double = 0.;
+    let mut error: ::core::ffi::c_double = 0.;
+    let mut vmnew: ::core::ffi::c_double = 0.;
+    let mut resmax: ::core::ffi::c_double = 0.;
+    let mut cvmaxp: ::core::ffi::c_double = 0.;
+    let mut resnew: ::core::ffi::c_double = 0.;
+    let mut trured: ::core::ffi::c_double = 0.;
+    let mut temp: ::core::ffi::c_double = 0.;
+    let mut wsig: ::core::ffi::c_double = 0.;
+    let mut f: ::core::ffi::c_double = 0.;
+    let mut weta: ::core::ffi::c_double = 0.;
+    let mut i__: ::core::ffi::c_int = 0;
+    let mut j: ::core::ffi::c_int = 0;
+    let mut k: ::core::ffi::c_int = 0;
+    let mut l: ::core::ffi::c_int = 0;
+    let mut idxnew: ::core::ffi::c_int = 0;
+    let mut iflag: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut iptemp: ::core::ffi::c_int = 0;
+    let mut isdirn: ::core::ffi::c_int = 0;
+    let mut izdota: ::core::ffi::c_int = 0;
+    let mut ivmc: ::core::ffi::c_int = 0;
+    let mut ivmd: ::core::ffi::c_int = 0;
+    let mut mp: ::core::ffi::c_int = 0;
+    let mut np: ::core::ffi::c_int = 0;
+    let mut iz: ::core::ffi::c_int = 0;
+    let mut ibrnch: ::core::ffi::c_int = 0;
+    let mut nbest: ::core::ffi::c_int = 0;
+    let mut ifull: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut iptem: ::core::ffi::c_int = 0;
+    let mut jdrop: ::core::ffi::c_int = 0;
     let mut rc: nlopt_result = NLOPT_SUCCESS;
     let mut seed: uint32_t = (*n + *m) as uint32_t;
-    let mut feasible: libc::c_int = 0;
+    let mut feasible: ::core::ffi::c_int = 0;
     *minf = f64::INFINITY;
     a_dim1 = *n;
-    a_offset = 1 as libc::c_int + a_dim1 * 1 as libc::c_int;
+    a_offset = 1 as ::core::ffi::c_int + a_dim1 * 1 as ::core::ffi::c_int;
     a = a.offset(-(a_offset as isize));
     simi_dim1 = *n;
-    simi_offset = 1 as libc::c_int + simi_dim1 * 1 as libc::c_int;
+    simi_offset = 1 as ::core::ffi::c_int + simi_dim1 * 1 as ::core::ffi::c_int;
     simi = simi.offset(-(simi_offset as isize));
     sim_dim1 = *n;
-    sim_offset = 1 as libc::c_int + sim_dim1 * 1 as libc::c_int;
+    sim_offset = 1 as ::core::ffi::c_int + sim_dim1 * 1 as ::core::ffi::c_int;
     sim = sim.offset(-(sim_offset as isize));
     datmat_dim1 = *mpp;
-    datmat_offset = 1 as libc::c_int + datmat_dim1 * 1 as libc::c_int;
+    datmat_offset = 1 as ::core::ffi::c_int + datmat_dim1 * 1 as ::core::ffi::c_int;
     datmat = datmat.offset(-(datmat_offset as isize));
     x = x.offset(-1);
     con = con.offset(-1);
@@ -1429,21 +1429,21 @@ unsafe fn cobylb(
     iact = iact.offset(-1);
     lb = lb.offset(-1);
     ub = ub.offset(-1);
-    iptem = if *n <= 4 as libc::c_int {
+    iptem = if *n <= 4 as ::core::ffi::c_int {
         *n
     } else {
-        4 as libc::c_int
+        4 as ::core::ffi::c_int
     };
-    iptemp = iptem + 1 as libc::c_int;
-    np = *n + 1 as libc::c_int;
-    mp = *m + 1 as libc::c_int;
+    iptemp = iptem + 1 as ::core::ffi::c_int;
+    np = *n + 1 as ::core::ffi::c_int;
+    mp = *m + 1 as ::core::ffi::c_int;
     alpha = 0.25f64;
     beta = 2.1f64;
     gamma_ = 0.5f64;
     delta = 1.1f64;
     rho = *rhobeg;
     parmu = 0.0f64;
-    if *iprint >= 2 as libc::c_int {
+    if *iprint >= 2 as ::core::ffi::c_int {
         fprintf(
             Io::stderr,
             &format!(
@@ -1454,12 +1454,12 @@ unsafe fn cobylb(
     }
     temp = 1.0f64 / rho;
     i__1 = *n;
-    i__ = 1 as libc::c_int;
+    i__ = 1 as ::core::ffi::c_int;
     while i__ <= i__1 {
-        let mut rhocur: libc::c_double = 0.;
+        let mut rhocur: ::core::ffi::c_double = 0.;
         *sim.offset((i__ + np * sim_dim1) as isize) = *x.offset(i__ as isize);
         i__2 = *n;
-        j = 1 as libc::c_int;
+        j = 1 as ::core::ffi::c_int;
         while j <= i__2 {
             *sim.offset((i__ + j * sim_dim1) as isize) = 0.0f64;
             *simi.offset((i__ + j * simi_dim1) as isize) = 0.0f64;
@@ -1482,18 +1482,18 @@ unsafe fn cobylb(
         i__ += 1;
     }
     jdrop = np;
-    ibrnch = 0 as libc::c_int;
+    ibrnch = 0 as ::core::ffi::c_int;
     'c_6104: loop {
         if nlopt_stop_forced(stop) != 0 {
             rc = NLOPT_FORCED_STOP;
-        } else if *(*stop).nevals_p > 0 as libc::c_int {
+        } else if *(*stop).nevals_p > 0 as ::core::ffi::c_int {
             if nlopt_stop_evals(stop) != 0 {
                 rc = NLOPT_MAXEVAL_REACHED;
             } else if nlopt_stop_time(stop) != 0 {
                 rc = NLOPT_MAXTIME_REACHED;
             }
         }
-        if rc as libc::c_int != NLOPT_SUCCESS as libc::c_int {
+        if rc as ::core::ffi::c_int != NLOPT_SUCCESS as ::core::ffi::c_int {
             current_block = 16949430136398296108;
             break;
         }
@@ -1502,13 +1502,13 @@ unsafe fn cobylb(
         if calcfc.expect("non-null function pointer")(
             *n,
             *m,
-            &mut *x.offset(1 as libc::c_int as isize),
+            &mut *x.offset(1 as ::core::ffi::c_int as isize),
             &mut f,
-            &mut *con.offset(1 as libc::c_int as isize),
+            &mut *con.offset(1 as ::core::ffi::c_int as isize),
             state,
         ) != 0
         {
-            if *iprint >= 1 as libc::c_int {
+            if *iprint >= 1 as ::core::ffi::c_int {
                 fprintf(Io::stderr, "cobyla: user requested end of minimization");
             }
             rc = NLOPT_FORCED_STOP;
@@ -1516,16 +1516,16 @@ unsafe fn cobylb(
             break;
         } else {
             resmax = 0.0f64;
-            feasible = 1 as libc::c_int;
-            if *m > 0 as libc::c_int {
+            feasible = 1 as ::core::ffi::c_int;
+            if *m > 0 as ::core::ffi::c_int {
                 i__1 = *m;
-                k = 1 as libc::c_int;
+                k = 1 as ::core::ffi::c_int;
                 while k <= i__1 {
                     d__1 = resmax;
                     d__2 = -*con.offset(k as isize);
                     resmax = if d__1 >= d__2 { d__1 } else { d__2 };
-                    if d__2 > *((*state).con_tol).offset((k - 1 as libc::c_int) as isize) {
-                        feasible = 0 as libc::c_int;
+                    if d__2 > *((*state).con_tol).offset((k - 1 as ::core::ffi::c_int) as isize) {
+                        feasible = 0 as ::core::ffi::c_int;
                     }
                     k += 1;
                 }
@@ -1535,7 +1535,7 @@ unsafe fn cobylb(
                 current_block = 10710279849762345920;
                 break;
             } else {
-                if *(*stop).nevals_p == *iprint - 1 as libc::c_int || *iprint == 3 as libc::c_int {
+                if *(*stop).nevals_p == *iprint - 1 as ::core::ffi::c_int || *iprint == 3 as ::core::ffi::c_int {
                     fprintf(
                         Io::stderr,
                         &format!(
@@ -1547,9 +1547,9 @@ unsafe fn cobylb(
                     );
                     i__1 = iptem;
                     fprintf(Io::stderr, "cobyla: X =");
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
-                        if i__ > 1 as libc::c_int {
+                        if i__ > 1 as ::core::ffi::c_int {
                             fprintf(Io::stderr, "  ");
                         }
                         fprintf(Io::stderr, &format!("{}", *x.offset(i__ as isize)));
@@ -1559,7 +1559,7 @@ unsafe fn cobylb(
                         i__1 = *n;
                         i__ = iptemp;
                         while i__ <= i__1 {
-                            if (i__ - 1 as libc::c_int) % 4 as libc::c_int == 0 {
+                            if (i__ - 1 as ::core::ffi::c_int) % 4 as ::core::ffi::c_int == 0 {
                                 fprintf(Io::stderr, "\ncobyla:  ");
                             }
                             fprintf(Io::stderr, &format!("{}", *x.offset(i__ as isize)));
@@ -1570,7 +1570,7 @@ unsafe fn cobylb(
                 }
                 *con.offset(mp as isize) = f;
                 *con.offset(*mpp as isize) = resmax;
-                if ibrnch == 1 as libc::c_int {
+                if ibrnch == 1 as ::core::ffi::c_int {
                     vmold = *datmat.offset((mp + np * datmat_dim1) as isize)
                         + parmu * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                     vmnew = f + parmu * resmax;
@@ -1580,16 +1580,16 @@ unsafe fn cobylb(
                         trured = *datmat.offset((*mpp + np * datmat_dim1) as isize) - resmax;
                     }
                     ratio = 0.0f64;
-                    if trured <= 0.0f32 as libc::c_double {
-                        ratio = 1.0f32 as libc::c_double;
+                    if trured <= 0.0f32 as ::core::ffi::c_double {
+                        ratio = 1.0f32 as ::core::ffi::c_double;
                     }
-                    jdrop = 0 as libc::c_int;
+                    jdrop = 0 as ::core::ffi::c_int;
                     i__1 = *n;
-                    j = 1 as libc::c_int;
+                    j = 1 as ::core::ffi::c_int;
                     while j <= i__1 {
                         temp = 0.0f64;
                         i__2 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__2 {
                             temp += *simi.offset((j + i__ * simi_dim1) as isize)
                                 * *dx.offset(i__ as isize);
@@ -1604,9 +1604,9 @@ unsafe fn cobylb(
                         j += 1;
                     }
                     edgmax = delta * rho;
-                    l = 0 as libc::c_int;
+                    l = 0 as ::core::ffi::c_int;
                     i__1 = *n;
-                    j = 1 as libc::c_int;
+                    j = 1 as ::core::ffi::c_int;
                     while j <= i__1 {
                         if *sigbar.offset(j as isize) >= parsig
                             || *sigbar.offset(j as isize) >= *vsig.offset(j as isize)
@@ -1615,7 +1615,7 @@ unsafe fn cobylb(
                             if trured > 0.0f64 {
                                 temp = 0.0f64;
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     d__1 = *dx.offset(i__ as isize)
                                         - *sim.offset((i__ + j * sim_dim1) as isize);
@@ -1631,15 +1631,15 @@ unsafe fn cobylb(
                         }
                         j += 1;
                     }
-                    if l > 0 as libc::c_int {
+                    if l > 0 as ::core::ffi::c_int {
                         jdrop = l;
                     }
-                    if jdrop == 0 as libc::c_int {
+                    if jdrop == 0 as ::core::ffi::c_int {
                         current_block = 17974563553836679504;
                     } else {
                         temp = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *sim.offset((i__ + jdrop * sim_dim1) as isize) =
                                 *dx.offset(i__ as isize);
@@ -1648,25 +1648,25 @@ unsafe fn cobylb(
                             i__ += 1;
                         }
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *simi.offset((jdrop + i__ * simi_dim1) as isize) /= temp;
                             i__ += 1;
                         }
                         i__1 = *n;
-                        j = 1 as libc::c_int;
+                        j = 1 as ::core::ffi::c_int;
                         while j <= i__1 {
                             if j != jdrop {
                                 temp = 0.0f64;
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     temp += *simi.offset((j + i__ * simi_dim1) as isize)
                                         * *dx.offset(i__ as isize);
                                     i__ += 1;
                                 }
                                 i__2 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__2 {
                                     *simi.offset((j + i__ * simi_dim1) as isize) -=
                                         temp * *simi.offset((jdrop + i__ * simi_dim1) as isize);
@@ -1676,7 +1676,7 @@ unsafe fn cobylb(
                             j += 1;
                         }
                         i__1 = *mpp;
-                        k = 1 as libc::c_int;
+                        k = 1 as ::core::ffi::c_int;
                         while k <= i__1 {
                             *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                                 *con.offset(k as isize);
@@ -1694,7 +1694,7 @@ unsafe fn cobylb(
                     }
                 } else {
                     i__1 = *mpp;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                             *con.offset(k as isize);
@@ -1706,12 +1706,12 @@ unsafe fn cobylb(
                                 *x.offset(jdrop as isize) =
                                     *sim.offset((jdrop + np * sim_dim1) as isize);
                             } else {
-                                let mut rhocur_0: libc::c_double = *x.offset(jdrop as isize)
+                                let mut rhocur_0: ::core::ffi::c_double = *x.offset(jdrop as isize)
                                     - *sim.offset((jdrop + np * sim_dim1) as isize);
                                 *sim.offset((jdrop + np * sim_dim1) as isize) =
                                     *x.offset(jdrop as isize);
                                 i__1 = *mpp;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__1 {
                                     *datmat.offset((k + jdrop * datmat_dim1) as isize) =
                                         *datmat.offset((k + np * datmat_dim1) as isize);
@@ -1720,10 +1720,10 @@ unsafe fn cobylb(
                                     k += 1;
                                 }
                                 i__1 = jdrop;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__1 {
                                     *sim.offset((jdrop + k * sim_dim1) as isize) = -rhocur_0;
-                                    temp = 0.0f32 as libc::c_double;
+                                    temp = 0.0f32 as ::core::ffi::c_double;
                                     i__2 = jdrop;
                                     i__ = k;
                                     while i__ <= i__2 {
@@ -1742,17 +1742,17 @@ unsafe fn cobylb(
                             continue;
                         }
                     }
-                    ibrnch = 1 as libc::c_int;
+                    ibrnch = 1 as ::core::ffi::c_int;
                     current_block = 16207618807156029286;
                 }
                 'c_6122: loop {
                     match current_block {
                         17974563553836679504 => {
-                            if iflag == 0 as libc::c_int {
-                                ibrnch = 0 as libc::c_int;
+                            if iflag == 0 as ::core::ffi::c_int {
+                                ibrnch = 0 as ::core::ffi::c_int;
                                 current_block = 16207618807156029286;
                             } else {
-                                let mut fbest: libc::c_double = if ifull == 1 as libc::c_int {
+                                let mut fbest: ::core::ffi::c_double = if ifull == 1 as ::core::ffi::c_int {
                                     f
                                 } else {
                                     *datmat.offset((mp + np * datmat_dim1) as isize)
@@ -1771,13 +1771,13 @@ unsafe fn cobylb(
                                         if parmu > 0.0f64 {
                                             denom = 0.0f64;
                                             i__1 = mp;
-                                            k = 1 as libc::c_int;
+                                            k = 1 as ::core::ffi::c_int;
                                             while k <= i__1 {
                                                 cmin =
                                                     *datmat.offset((k + np * datmat_dim1) as isize);
                                                 cmax = cmin;
                                                 i__2 = *n;
-                                                i__ = 1 as libc::c_int;
+                                                i__ = 1 as ::core::ffi::c_int;
                                                 while i__ <= i__2 {
                                                     d__1 = cmin;
                                                     d__2 = *datmat
@@ -1813,7 +1813,7 @@ unsafe fn cobylb(
                                                 parmu = (cmax - cmin) / denom;
                                             }
                                         }
-                                        if *iprint >= 2 as libc::c_int {
+                                        if *iprint >= 2 as ::core::ffi::c_int {
                                             fprintf(
                                                 Io::stderr,
                                                 &format!(
@@ -1822,7 +1822,7 @@ unsafe fn cobylb(
                                                 ),
                                             );
                                         }
-                                        if *iprint == 2 as libc::c_int {
+                                        if *iprint == 2 as ::core::ffi::c_int {
                                             fprintf(
                                                 Io::stderr,
                                                 &format!(
@@ -1836,9 +1836,9 @@ unsafe fn cobylb(
                                             );
                                             fprintf(Io::stderr, "cobyla: X =");
                                             i__1 = iptem;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__1 {
-                                                if i__ > 1 as libc::c_int {
+                                                if i__ > 1 as ::core::ffi::c_int {
                                                     fprintf(Io::stderr, "  ");
                                                 }
                                                 fprintf(
@@ -1854,7 +1854,7 @@ unsafe fn cobylb(
                                                 i__1 = *n;
                                                 i__ = iptemp;
                                                 while i__ <= i__1 {
-                                                    if (i__ - 1 as libc::c_int) % 4 as libc::c_int
+                                                    if (i__ - 1 as ::core::ffi::c_int) % 4 as ::core::ffi::c_int
                                                         == 0
                                                     {
                                                         fprintf(Io::stderr, "\ncobyla:  ");
@@ -1870,16 +1870,16 @@ unsafe fn cobylb(
                                         }
                                         current_block = 16207618807156029286;
                                     } else {
-                                        rc = (if rhoend > 0 as libc::c_int as libc::c_double {
-                                            NLOPT_XTOL_REACHED as libc::c_int
+                                        rc = (if rhoend > 0 as ::core::ffi::c_int as ::core::ffi::c_double {
+                                            NLOPT_XTOL_REACHED as ::core::ffi::c_int
                                         } else {
-                                            NLOPT_ROUNDOFF_LIMITED as libc::c_int
+                                            NLOPT_ROUNDOFF_LIMITED as ::core::ffi::c_int
                                         })
                                             as nlopt_result;
-                                        if *iprint >= 1 as libc::c_int {
+                                        if *iprint >= 1 as ::core::ffi::c_int {
                                             fprintf(Io::stderr, "cobyla: normal return.");
                                         }
-                                        if ifull == 1 as libc::c_int {
+                                        if ifull == 1 as ::core::ffi::c_int {
                                             current_block = 10710279849762345920;
                                             break 'c_6104;
                                         } else {
@@ -1895,7 +1895,7 @@ unsafe fn cobylb(
                                 + parmu * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                             nbest = np;
                             i__1 = *n;
-                            j = 1 as libc::c_int;
+                            j = 1 as ::core::ffi::c_int;
                             while j <= i__1 {
                                 temp = *datmat.offset((mp + j * datmat_dim1) as isize)
                                     + parmu * *datmat.offset((*mpp + j * datmat_dim1) as isize);
@@ -1913,7 +1913,7 @@ unsafe fn cobylb(
                             }
                             if nbest <= *n {
                                 i__1 = *mpp;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *datmat.offset((i__ + np * datmat_dim1) as isize);
                                     *datmat.offset((i__ + np * datmat_dim1) as isize) =
@@ -1922,14 +1922,14 @@ unsafe fn cobylb(
                                     i__ += 1;
                                 }
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *sim.offset((i__ + nbest * sim_dim1) as isize);
                                     *sim.offset((i__ + nbest * sim_dim1) as isize) = 0.0f64;
                                     *sim.offset((i__ + np * sim_dim1) as isize) += temp;
                                     tempa = 0.0f64;
                                     i__2 = *n;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__2 {
                                         *sim.offset((i__ + k * sim_dim1) as isize) -= temp;
                                         tempa -= *simi.offset((k + i__ * simi_dim1) as isize);
@@ -1941,20 +1941,20 @@ unsafe fn cobylb(
                             }
                             error = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 i__2 = *n;
-                                j = 1 as libc::c_int;
+                                j = 1 as ::core::ffi::c_int;
                                 while j <= i__2 {
                                     temp = 0.0f64;
                                     if i__ == j {
                                         temp += -1.0f64;
                                     }
                                     i__3 = *n;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__3 {
                                         if *sim.offset((k + j * sim_dim1) as isize)
-                                            != 0 as libc::c_int as libc::c_double
+                                            != 0 as ::core::ffi::c_int as ::core::ffi::c_double
                                         {
                                             temp += *simi.offset((i__ + k * simi_dim1) as isize)
                                                 * *sim.offset((k + j * sim_dim1) as isize);
@@ -1969,7 +1969,7 @@ unsafe fn cobylb(
                                 i__ += 1;
                             }
                             if error > 0.1f64 {
-                                if *iprint >= 1 as libc::c_int {
+                                if *iprint >= 1 as ::core::ffi::c_int {
                                     fprintf(
                                         Io::stderr,
                                         "cobyla: rounding errors are becoming damaging.",
@@ -1980,12 +1980,12 @@ unsafe fn cobylb(
                                 break 'c_6104;
                             } else {
                                 i__2 = mp;
-                                k = 1 as libc::c_int;
+                                k = 1 as ::core::ffi::c_int;
                                 while k <= i__2 {
                                     *con.offset(k as isize) =
                                         -*datmat.offset((k + np * datmat_dim1) as isize);
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         *w.offset(j as isize) = *datmat
                                             .offset((k + j * datmat_dim1) as isize)
@@ -1993,11 +1993,11 @@ unsafe fn cobylb(
                                         j += 1;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         temp = 0.0f64;
                                         i__3 = *n;
-                                        j = 1 as libc::c_int;
+                                        j = 1 as ::core::ffi::c_int;
                                         while j <= i__3 {
                                             temp += *w.offset(j as isize)
                                                 * *simi.offset((j + i__ * simi_dim1) as isize);
@@ -2011,16 +2011,16 @@ unsafe fn cobylb(
                                     }
                                     k += 1;
                                 }
-                                iflag = 1 as libc::c_int;
+                                iflag = 1 as ::core::ffi::c_int;
                                 parsig = alpha * rho;
                                 pareta = beta * rho;
                                 i__1 = *n;
-                                j = 1 as libc::c_int;
+                                j = 1 as ::core::ffi::c_int;
                                 while j <= i__1 {
                                     wsig = 0.0f64;
                                     weta = 0.0f64;
                                     i__2 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__2 {
                                         d__1 = *simi.offset((j + i__ * simi_dim1) as isize);
                                         wsig += d__1 * d__1;
@@ -2033,12 +2033,12 @@ unsafe fn cobylb(
                                     if *vsig.offset(j as isize) < parsig
                                         || *veta.offset(j as isize) > pareta
                                     {
-                                        iflag = 0 as libc::c_int;
+                                        iflag = 0 as ::core::ffi::c_int;
                                     }
                                     j += 1;
                                 }
-                                if ibrnch == 1 as libc::c_int || iflag == 1 as libc::c_int {
-                                    iz = 1 as libc::c_int;
+                                if ibrnch == 1 as ::core::ffi::c_int || iflag == 1 as ::core::ffi::c_int {
+                                    iz = 1 as ::core::ffi::c_int;
                                     izdota = iz + *n * *n;
                                     ivmc = izdota + *n;
                                     isdirn = ivmc + mp;
@@ -2048,11 +2048,11 @@ unsafe fn cobylb(
                                         n,
                                         m,
                                         &mut *a.offset(a_offset as isize),
-                                        &mut *con.offset(1 as libc::c_int as isize),
+                                        &mut *con.offset(1 as ::core::ffi::c_int as isize),
                                         &mut rho,
-                                        &mut *dx.offset(1 as libc::c_int as isize),
+                                        &mut *dx.offset(1 as ::core::ffi::c_int as isize),
                                         &mut ifull,
-                                        &mut *iact.offset(1 as libc::c_int as isize),
+                                        &mut *iact.offset(1 as ::core::ffi::c_int as isize),
                                         &mut *w.offset(iz as isize),
                                         &mut *w.offset(izdota as isize),
                                         &mut *w.offset(ivmc as isize),
@@ -2060,14 +2060,14 @@ unsafe fn cobylb(
                                         &mut *w.offset(idxnew as isize),
                                         &mut *w.offset(ivmd as isize),
                                     );
-                                    if rc as libc::c_int != NLOPT_SUCCESS as libc::c_int {
+                                    if rc as ::core::ffi::c_int != NLOPT_SUCCESS as ::core::ffi::c_int {
                                         current_block = 16949430136398296108;
                                         break 'c_6104;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
-                                        let mut xi_0: libc::c_double =
+                                        let mut xi_0: ::core::ffi::c_double =
                                             *sim.offset((i__ + np * sim_dim1) as isize);
                                         if xi_0 + *dx.offset(i__ as isize)
                                             > *ub.offset(i__ as isize)
@@ -2083,17 +2083,17 @@ unsafe fn cobylb(
                                         }
                                         i__ += 1;
                                     }
-                                    if ifull == 0 as libc::c_int {
+                                    if ifull == 0 as ::core::ffi::c_int {
                                         temp = 0.0f64;
                                         i__1 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__1 {
                                             d__1 = *dx.offset(i__ as isize);
                                             temp += d__1 * d__1;
                                             i__ += 1;
                                         }
                                         if temp < rho * 0.25f64 * rho {
-                                            ibrnch = 1 as libc::c_int;
+                                            ibrnch = 1 as ::core::ffi::c_int;
                                             current_block = 17974563553836679504;
                                             continue;
                                         }
@@ -2101,11 +2101,11 @@ unsafe fn cobylb(
                                     resnew = 0.0f64;
                                     *con.offset(mp as isize) = 0.0f64;
                                     i__1 = mp;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__1 {
                                         sum = *con.offset(k as isize);
                                         i__2 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__2 {
                                             sum -= *a.offset((i__ + k * a_dim1) as isize)
                                                 * *dx.offset(i__ as isize);
@@ -2126,7 +2126,7 @@ unsafe fn cobylb(
                                         break;
                                     }
                                     parmu = barmu * 2.0f64;
-                                    if *iprint >= 2 as libc::c_int {
+                                    if *iprint >= 2 as ::core::ffi::c_int {
                                         fprintf(
                                             Io::stderr,
                                             &format!("cobyla: increase in PARMU to {}", parmu),
@@ -2136,7 +2136,7 @@ unsafe fn cobylb(
                                         + parmu
                                             * *datmat.offset((*mpp + np * datmat_dim1) as isize);
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     loop {
                                         if !(j <= i__1) {
                                             break 'c_6122;
@@ -2148,7 +2148,7 @@ unsafe fn cobylb(
                                             current_block = 16207618807156029286;
                                             break;
                                         }
-                                        if temp == phi && parmu == 0.0f32 as libc::c_double {
+                                        if temp == phi && parmu == 0.0f32 as ::core::ffi::c_double {
                                             if *datmat.offset((*mpp + j * datmat_dim1) as isize)
                                                 < *datmat.offset((*mpp + np * datmat_dim1) as isize)
                                             {
@@ -2159,10 +2159,10 @@ unsafe fn cobylb(
                                         j += 1;
                                     }
                                 } else {
-                                    jdrop = 0 as libc::c_int;
+                                    jdrop = 0 as ::core::ffi::c_int;
                                     temp = pareta;
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         if *veta.offset(j as isize) > temp {
                                             jdrop = j;
@@ -2170,9 +2170,9 @@ unsafe fn cobylb(
                                         }
                                         j += 1;
                                     }
-                                    if jdrop == 0 as libc::c_int {
+                                    if jdrop == 0 as ::core::ffi::c_int {
                                         i__1 = *n;
-                                        j = 1 as libc::c_int;
+                                        j = 1 as ::core::ffi::c_int;
                                         while j <= i__1 {
                                             if *vsig.offset(j as isize) < temp {
                                                 jdrop = j;
@@ -2183,7 +2183,7 @@ unsafe fn cobylb(
                                     }
                                     temp = gamma_ * rho * *vsig.offset(jdrop as isize);
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *dx.offset(i__ as isize) =
                                             temp * *simi.offset((jdrop + i__ * simi_dim1) as isize);
@@ -2192,11 +2192,11 @@ unsafe fn cobylb(
                                     cvmaxp = 0.0f64;
                                     cvmaxm = 0.0f64;
                                     i__1 = mp;
-                                    k = 1 as libc::c_int;
+                                    k = 1 as ::core::ffi::c_int;
                                     while k <= i__1 {
                                         sum = 0.0f64;
                                         i__2 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__2 {
                                             sum += *a.offset((i__ + k * a_dim1) as isize)
                                                 * *dx.offset(i__ as isize);
@@ -2219,16 +2219,16 @@ unsafe fn cobylb(
                                     }
                                     temp = 0.0f64;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *dx.offset(i__ as isize) = dxsign
                                             * *dx.offset(i__ as isize)
                                             * lcg_urand(
                                                 &mut seed,
                                                 0.01f64,
-                                                1 as libc::c_int as libc::c_double,
+                                                1 as ::core::ffi::c_int as ::core::ffi::c_double,
                                             );
-                                        let mut xi: libc::c_double =
+                                        let mut xi: ::core::ffi::c_double =
                                             *sim.offset((i__ + np * sim_dim1) as isize);
                                         loop {
                                             if xi + *dx.offset(i__ as isize)
@@ -2259,18 +2259,18 @@ unsafe fn cobylb(
                                         i__ += 1;
                                     }
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         *simi.offset((jdrop + i__ * simi_dim1) as isize) /= temp;
                                         i__ += 1;
                                     }
                                     i__1 = *n;
-                                    j = 1 as libc::c_int;
+                                    j = 1 as ::core::ffi::c_int;
                                     while j <= i__1 {
                                         if j != jdrop {
                                             temp = 0.0f64;
                                             i__2 = *n;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__2 {
                                                 temp += *simi
                                                     .offset((j + i__ * simi_dim1) as isize)
@@ -2278,7 +2278,7 @@ unsafe fn cobylb(
                                                 i__ += 1;
                                             }
                                             i__2 = *n;
-                                            i__ = 1 as libc::c_int;
+                                            i__ = 1 as ::core::ffi::c_int;
                                             while i__ <= i__2 {
                                                 *simi.offset((j + i__ * simi_dim1) as isize) -= temp
                                                     * *simi
@@ -2299,20 +2299,20 @@ unsafe fn cobylb(
                 }
                 prerem = parmu * prerec - sum;
                 i__1 = *n;
-                i__ = 1 as libc::c_int;
+                i__ = 1 as ::core::ffi::c_int;
                 while i__ <= i__1 {
                     *x.offset(i__ as isize) =
                         *sim.offset((i__ + np * sim_dim1) as isize) + *dx.offset(i__ as isize);
                     i__ += 1;
                 }
-                ibrnch = 1 as libc::c_int;
+                ibrnch = 1 as ::core::ffi::c_int;
             }
         }
     }
     match current_block {
         16949430136398296108 => {
             i__1 = *n;
-            i__ = 1 as libc::c_int;
+            i__ = 1 as ::core::ffi::c_int;
             while i__ <= i__1 {
                 *x.offset(i__ as isize) = *sim.offset((i__ + np * sim_dim1) as isize);
                 i__ += 1;
@@ -2323,7 +2323,7 @@ unsafe fn cobylb(
         _ => {}
     }
     *minf = f;
-    if *iprint >= 1 as libc::c_int {
+    if *iprint >= 1 as ::core::ffi::c_int {
         fprintf(
             Io::stderr,
             &format!(
@@ -2335,9 +2335,9 @@ unsafe fn cobylb(
         );
         i__1 = iptem;
         fprintf(Io::stderr, "cobyla: X =");
-        i__ = 1 as libc::c_int;
+        i__ = 1 as ::core::ffi::c_int;
         while i__ <= i__1 {
-            if i__ > 1 as libc::c_int {
+            if i__ > 1 as ::core::ffi::c_int {
                 fprintf(Io::stderr, "  ");
             }
             fprintf(Io::stderr, &format!("{}", *x.offset(i__ as isize)));
@@ -2347,7 +2347,7 @@ unsafe fn cobylb(
             i__1 = *n;
             i__ = iptemp;
             while i__ <= i__1 {
-                if (i__ - 1 as libc::c_int) % 4 as libc::c_int == 0 {
+                if (i__ - 1 as ::core::ffi::c_int) % 4 as ::core::ffi::c_int == 0 {
                     fprintf(Io::stderr, "\ncobyla:  ");
                 }
                 fprintf(Io::stderr, &format!("{}", *x.offset(i__ as isize)));
@@ -2359,74 +2359,74 @@ unsafe fn cobylb(
     rc
 }
 unsafe fn trstlp(
-    mut n: *mut libc::c_int,
-    mut m: *mut libc::c_int,
-    mut a: *mut libc::c_double,
-    mut b: *mut libc::c_double,
-    mut rho: *mut libc::c_double,
-    mut dx: *mut libc::c_double,
-    mut ifull: *mut libc::c_int,
-    mut iact: *mut libc::c_int,
-    mut z__: *mut libc::c_double,
-    mut zdota: *mut libc::c_double,
-    mut vmultc: *mut libc::c_double,
-    mut sdirn: *mut libc::c_double,
-    mut dxnew: *mut libc::c_double,
-    mut vmultd: *mut libc::c_double,
+    mut n: *mut ::core::ffi::c_int,
+    mut m: *mut ::core::ffi::c_int,
+    mut a: *mut ::core::ffi::c_double,
+    mut b: *mut ::core::ffi::c_double,
+    mut rho: *mut ::core::ffi::c_double,
+    mut dx: *mut ::core::ffi::c_double,
+    mut ifull: *mut ::core::ffi::c_int,
+    mut iact: *mut ::core::ffi::c_int,
+    mut z__: *mut ::core::ffi::c_double,
+    mut zdota: *mut ::core::ffi::c_double,
+    mut vmultc: *mut ::core::ffi::c_double,
+    mut sdirn: *mut ::core::ffi::c_double,
+    mut dxnew: *mut ::core::ffi::c_double,
+    mut vmultd: *mut ::core::ffi::c_double,
 ) -> nlopt_result {
     let mut current_block: u64;
-    let mut a_dim1: libc::c_int = 0;
-    let mut a_offset: libc::c_int = 0;
-    let mut z_dim1: libc::c_int = 0;
-    let mut z_offset: libc::c_int = 0;
-    let mut i__1: libc::c_int = 0;
-    let mut i__2: libc::c_int = 0;
-    let mut d__1: libc::c_double = 0.;
-    let mut d__2: libc::c_double = 0.;
-    let mut alpha: libc::c_double = 0.;
-    let mut tempa: libc::c_double = 0.;
-    let mut beta: libc::c_double = 0.;
-    let mut optnew: libc::c_double = 0.;
-    let mut stpful: libc::c_double = 0.;
-    let mut sum: libc::c_double = 0.;
-    let mut tot: libc::c_double = 0.;
-    let mut acca: libc::c_double = 0.;
-    let mut accb: libc::c_double = 0.;
-    let mut ratio: libc::c_double = 0.;
-    let mut vsave: libc::c_double = 0.;
-    let mut zdotv: libc::c_double = 0.;
-    let mut zdotw: libc::c_double = 0.;
-    let mut dd: libc::c_double = 0.;
-    let mut sd: libc::c_double = 0.;
-    let mut sp: libc::c_double = 0.;
-    let mut ss: libc::c_double = 0.;
-    let mut resold: libc::c_double = 0.0f64;
-    let mut zdvabs: libc::c_double = 0.;
-    let mut zdwabs: libc::c_double = 0.;
-    let mut sumabs: libc::c_double = 0.;
-    let mut resmax: libc::c_double = 0.;
-    let mut optold: libc::c_double = 0.;
-    let mut spabs: libc::c_double = 0.;
-    let mut temp: libc::c_double = 0.;
-    let mut step: libc::c_double = 0.;
-    let mut icount: libc::c_int = 0;
-    let mut i__: libc::c_int = 0;
-    let mut j: libc::c_int = 0;
-    let mut k: libc::c_int = 0;
-    let mut isave: libc::c_int = 0;
-    let mut kk: libc::c_int = 0;
-    let mut kl: libc::c_int = 0;
-    let mut kp: libc::c_int = 0;
-    let mut kw: libc::c_int = 0;
-    let mut nact: libc::c_int = 0;
-    let mut icon: libc::c_int = 0 as libc::c_int;
-    let mut mcon: libc::c_int = 0;
-    let mut nactx: libc::c_int = 0 as libc::c_int;
+    let mut a_dim1: ::core::ffi::c_int = 0;
+    let mut a_offset: ::core::ffi::c_int = 0;
+    let mut z_dim1: ::core::ffi::c_int = 0;
+    let mut z_offset: ::core::ffi::c_int = 0;
+    let mut i__1: ::core::ffi::c_int = 0;
+    let mut i__2: ::core::ffi::c_int = 0;
+    let mut d__1: ::core::ffi::c_double = 0.;
+    let mut d__2: ::core::ffi::c_double = 0.;
+    let mut alpha: ::core::ffi::c_double = 0.;
+    let mut tempa: ::core::ffi::c_double = 0.;
+    let mut beta: ::core::ffi::c_double = 0.;
+    let mut optnew: ::core::ffi::c_double = 0.;
+    let mut stpful: ::core::ffi::c_double = 0.;
+    let mut sum: ::core::ffi::c_double = 0.;
+    let mut tot: ::core::ffi::c_double = 0.;
+    let mut acca: ::core::ffi::c_double = 0.;
+    let mut accb: ::core::ffi::c_double = 0.;
+    let mut ratio: ::core::ffi::c_double = 0.;
+    let mut vsave: ::core::ffi::c_double = 0.;
+    let mut zdotv: ::core::ffi::c_double = 0.;
+    let mut zdotw: ::core::ffi::c_double = 0.;
+    let mut dd: ::core::ffi::c_double = 0.;
+    let mut sd: ::core::ffi::c_double = 0.;
+    let mut sp: ::core::ffi::c_double = 0.;
+    let mut ss: ::core::ffi::c_double = 0.;
+    let mut resold: ::core::ffi::c_double = 0.0f64;
+    let mut zdvabs: ::core::ffi::c_double = 0.;
+    let mut zdwabs: ::core::ffi::c_double = 0.;
+    let mut sumabs: ::core::ffi::c_double = 0.;
+    let mut resmax: ::core::ffi::c_double = 0.;
+    let mut optold: ::core::ffi::c_double = 0.;
+    let mut spabs: ::core::ffi::c_double = 0.;
+    let mut temp: ::core::ffi::c_double = 0.;
+    let mut step: ::core::ffi::c_double = 0.;
+    let mut icount: ::core::ffi::c_int = 0;
+    let mut i__: ::core::ffi::c_int = 0;
+    let mut j: ::core::ffi::c_int = 0;
+    let mut k: ::core::ffi::c_int = 0;
+    let mut isave: ::core::ffi::c_int = 0;
+    let mut kk: ::core::ffi::c_int = 0;
+    let mut kl: ::core::ffi::c_int = 0;
+    let mut kp: ::core::ffi::c_int = 0;
+    let mut kw: ::core::ffi::c_int = 0;
+    let mut nact: ::core::ffi::c_int = 0;
+    let mut icon: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
+    let mut mcon: ::core::ffi::c_int = 0;
+    let mut nactx: ::core::ffi::c_int = 0 as ::core::ffi::c_int;
     z_dim1 = *n;
-    z_offset = 1 as libc::c_int + z_dim1 * 1 as libc::c_int;
+    z_offset = 1 as ::core::ffi::c_int + z_dim1 * 1 as ::core::ffi::c_int;
     z__ = z__.offset(-(z_offset as isize));
     a_dim1 = *n;
-    a_offset = 1 as libc::c_int + a_dim1 * 1 as libc::c_int;
+    a_offset = 1 as ::core::ffi::c_int + a_dim1 * 1 as ::core::ffi::c_int;
     a = a.offset(-(a_offset as isize));
     b = b.offset(-1);
     dx = dx.offset(-1);
@@ -2436,15 +2436,15 @@ unsafe fn trstlp(
     sdirn = sdirn.offset(-1);
     dxnew = dxnew.offset(-1);
     vmultd = vmultd.offset(-1);
-    *ifull = 1 as libc::c_int;
+    *ifull = 1 as ::core::ffi::c_int;
     mcon = *m;
-    nact = 0 as libc::c_int;
+    nact = 0 as ::core::ffi::c_int;
     resmax = 0.0f64;
     i__1 = *n;
-    i__ = 1 as libc::c_int;
+    i__ = 1 as ::core::ffi::c_int;
     while i__ <= i__1 {
         i__2 = *n;
-        j = 1 as libc::c_int;
+        j = 1 as ::core::ffi::c_int;
         while j <= i__2 {
             *z__.offset((i__ + j * z_dim1) as isize) = 0.0f64;
             j += 1;
@@ -2453,9 +2453,9 @@ unsafe fn trstlp(
         *dx.offset(i__ as isize) = 0.0f64;
         i__ += 1;
     }
-    if *m >= 1 as libc::c_int {
+    if *m >= 1 as ::core::ffi::c_int {
         i__1 = *m;
-        k = 1 as libc::c_int;
+        k = 1 as ::core::ffi::c_int;
         while k <= i__1 {
             if *b.offset(k as isize) > resmax {
                 resmax = *b.offset(k as isize);
@@ -2464,7 +2464,7 @@ unsafe fn trstlp(
             k += 1;
         }
         i__1 = *m;
-        k = 1 as libc::c_int;
+        k = 1 as ::core::ffi::c_int;
         while k <= i__1 {
             *iact.offset(k as isize) = k;
             *vmultc.offset(k as isize) = resmax - *b.offset(k as isize);
@@ -2475,7 +2475,7 @@ unsafe fn trstlp(
         current_block = 11188143500741601598;
     } else {
         i__1 = *n;
-        i__ = 1 as libc::c_int;
+        i__ = 1 as ::core::ffi::c_int;
         while i__ <= i__1 {
             *sdirn.offset(i__ as isize) = 0.0f64;
             i__ += 1;
@@ -2485,7 +2485,7 @@ unsafe fn trstlp(
     'c_8601: loop {
         match current_block {
             11188143500741601598 => {
-                mcon = *m + 1 as libc::c_int;
+                mcon = *m + 1 as ::core::ffi::c_int;
                 icon = mcon;
                 *iact.offset(mcon as isize) = mcon;
                 *vmultc.offset(mcon as isize) = 0.0f64;
@@ -2493,30 +2493,30 @@ unsafe fn trstlp(
             }
             _ => {
                 optold = 0.0f64;
-                icount = 0 as libc::c_int;
+                icount = 0 as ::core::ffi::c_int;
                 loop {
                     if mcon == *m {
                         optnew = resmax;
                     } else {
                         optnew = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             optnew -= *dx.offset(i__ as isize)
                                 * *a.offset((i__ + mcon * a_dim1) as isize);
                             i__ += 1;
                         }
                     }
-                    if icount == 0 as libc::c_int || optnew < optold {
+                    if icount == 0 as ::core::ffi::c_int || optnew < optold {
                         optold = optnew;
                         nactx = nact;
-                        icount = 3 as libc::c_int;
+                        icount = 3 as ::core::ffi::c_int;
                     } else if nact > nactx {
                         nactx = nact;
-                        icount = 3 as libc::c_int;
+                        icount = 3 as ::core::ffi::c_int;
                     } else {
                         icount -= 1;
-                        if icount == 0 as libc::c_int {
+                        if icount == 0 as ::core::ffi::c_int {
                             break;
                         }
                     }
@@ -2526,11 +2526,11 @@ unsafe fn trstlp(
                             vsave = *vmultc.offset(icon as isize);
                             k = icon;
                             loop {
-                                kp = k + 1 as libc::c_int;
+                                kp = k + 1 as ::core::ffi::c_int;
                                 kk = *iact.offset(kp as isize);
                                 sp = 0.0f64;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     sp += *z__.offset((i__ + k * z_dim1) as isize)
                                         * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2543,7 +2543,7 @@ unsafe fn trstlp(
                                 *zdota.offset(kp as isize) = alpha * *zdota.offset(k as isize);
                                 *zdota.offset(k as isize) = temp;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = alpha * *z__.offset((i__ + kp * z_dim1) as isize)
                                         + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2569,20 +2569,20 @@ unsafe fn trstlp(
                         } else {
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *sdirn.offset(i__ as isize)
                                     * *z__.offset(
-                                        (i__ + (nact + 1 as libc::c_int) * z_dim1) as isize,
+                                        (i__ + (nact + 1 as ::core::ffi::c_int) * z_dim1) as isize,
                                     );
                                 i__ += 1;
                             }
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) -= temp
                                     * *z__.offset(
-                                        (i__ + (nact + 1 as libc::c_int) * z_dim1) as isize,
+                                        (i__ + (nact + 1 as ::core::ffi::c_int) * z_dim1) as isize,
                                     );
                                 i__ += 1;
                             }
@@ -2591,7 +2591,7 @@ unsafe fn trstlp(
                     } else {
                         kk = *iact.offset(icon as isize);
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *dxnew.offset(i__ as isize) = *a.offset((i__ + kk * a_dim1) as isize);
                             i__ += 1;
@@ -2602,7 +2602,7 @@ unsafe fn trstlp(
                             sp = 0.0f64;
                             spabs = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp = *z__.offset((i__ + k * z_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2618,13 +2618,13 @@ unsafe fn trstlp(
                             if tot == 0.0f64 {
                                 tot = sp;
                             } else {
-                                kp = k + 1 as libc::c_int;
+                                kp = k + 1 as ::core::ffi::c_int;
                                 temp = (sp * sp + tot * tot).sqrt();
                                 alpha = sp / temp;
                                 beta = tot / temp;
                                 tot = temp;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = alpha * *z__.offset((i__ + k * z_dim1) as isize)
                                         + beta * *z__.offset((i__ + kp * z_dim1) as isize);
@@ -2649,7 +2649,7 @@ unsafe fn trstlp(
                                 zdotv = 0.0f64;
                                 zdvabs = 0.0f64;
                                 i__1 = *n;
-                                i__ = 1 as libc::c_int;
+                                i__ = 1 as ::core::ffi::c_int;
                                 while i__ <= i__1 {
                                     temp = *z__.offset((i__ + k * z_dim1) as isize)
                                         * *dxnew.offset(i__ as isize);
@@ -2667,10 +2667,10 @@ unsafe fn trstlp(
                                             ratio = tempa;
                                         }
                                     }
-                                    if k >= 2 as libc::c_int {
+                                    if k >= 2 as ::core::ffi::c_int {
                                         kw = *iact.offset(k as isize);
                                         i__1 = *n;
-                                        i__ = 1 as libc::c_int;
+                                        i__ = 1 as ::core::ffi::c_int;
                                         while i__ <= i__1 {
                                             *dxnew.offset(i__ as isize) -=
                                                 temp * *a.offset((i__ + kw * a_dim1) as isize);
@@ -2682,7 +2682,7 @@ unsafe fn trstlp(
                                     *vmultd.offset(k as isize) = 0.0f64;
                                 }
                                 k -= 1;
-                                if !(k > 0 as libc::c_int) {
+                                if !(k > 0 as ::core::ffi::c_int) {
                                     break;
                                 }
                             }
@@ -2690,7 +2690,7 @@ unsafe fn trstlp(
                                 break;
                             }
                             i__1 = nact;
-                            k = 1 as libc::c_int;
+                            k = 1 as ::core::ffi::c_int;
                             while k <= i__1 {
                                 d__1 = 0.0f64;
                                 d__2 =
@@ -2703,11 +2703,11 @@ unsafe fn trstlp(
                                 vsave = *vmultc.offset(icon as isize);
                                 k = icon;
                                 loop {
-                                    kp = k + 1 as libc::c_int;
+                                    kp = k + 1 as ::core::ffi::c_int;
                                     kw = *iact.offset(kp as isize);
                                     sp = 0.0f64;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         sp += *z__.offset((i__ + k * z_dim1) as isize)
                                             * *a.offset((i__ + kw * a_dim1) as isize);
@@ -2720,7 +2720,7 @@ unsafe fn trstlp(
                                     *zdota.offset(kp as isize) = alpha * *zdota.offset(k as isize);
                                     *zdota.offset(k as isize) = temp;
                                     i__1 = *n;
-                                    i__ = 1 as libc::c_int;
+                                    i__ = 1 as ::core::ffi::c_int;
                                     while i__ <= i__1 {
                                         temp = alpha * *z__.offset((i__ + kp * z_dim1) as isize)
                                             + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2742,7 +2742,7 @@ unsafe fn trstlp(
                             }
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *z__.offset((i__ + nact * z_dim1) as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2758,10 +2758,10 @@ unsafe fn trstlp(
                         *iact.offset(icon as isize) = *iact.offset(nact as isize);
                         *iact.offset(nact as isize) = kk;
                         if mcon > *m && kk != mcon {
-                            k = nact - 1 as libc::c_int;
+                            k = nact - 1 as ::core::ffi::c_int;
                             sp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 sp += *z__.offset((i__ + k * z_dim1) as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2774,7 +2774,7 @@ unsafe fn trstlp(
                             *zdota.offset(nact as isize) = alpha * *zdota.offset(k as isize);
                             *zdota.offset(k as isize) = temp;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp = alpha * *z__.offset((i__ + nact * z_dim1) as isize)
                                     + beta * *z__.offset((i__ + k * z_dim1) as isize);
@@ -2796,7 +2796,7 @@ unsafe fn trstlp(
                             kk = *iact.offset(nact as isize);
                             temp = 0.0f64;
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 temp += *sdirn.offset(i__ as isize)
                                     * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2805,7 +2805,7 @@ unsafe fn trstlp(
                             temp += -1.0f64;
                             temp /= *zdota.offset(nact as isize);
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) -=
                                     temp * *z__.offset((i__ + nact * z_dim1) as isize);
@@ -2818,7 +2818,7 @@ unsafe fn trstlp(
                         15623375721314334080 => {
                             temp = 1.0f64 / *zdota.offset(nact as isize);
                             i__1 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__1 {
                                 *sdirn.offset(i__ as isize) =
                                     temp * *z__.offset((i__ + nact * z_dim1) as isize);
@@ -2831,10 +2831,10 @@ unsafe fn trstlp(
                     sd = 0.0f64;
                     ss = 0.0f64;
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         d__1 = *dx.offset(i__ as isize);
-                        if (d__1).abs() >= *rho * 1e-6f32 as libc::c_double {
+                        if (d__1).abs() >= *rho * 1e-6f32 as ::core::ffi::c_double {
                             d__2 = *dx.offset(i__ as isize);
                             dd -= d__2 * d__2;
                         }
@@ -2847,7 +2847,7 @@ unsafe fn trstlp(
                         break;
                     }
                     temp = (ss * dd).sqrt();
-                    if (sd).abs() >= temp * 1e-6f32 as libc::c_double {
+                    if (sd).abs() >= temp * 1e-6f32 as ::core::ffi::c_double {
                         temp = (ss * dd + sd * sd).sqrt();
                     }
                     stpful = dd / (temp + sd);
@@ -2865,7 +2865,7 @@ unsafe fn trstlp(
                         return NLOPT_ROUNDOFF_LIMITED;
                     }
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dxnew.offset(i__ as isize) =
                             *dx.offset(i__ as isize) + step * *sdirn.offset(i__ as isize);
@@ -2875,12 +2875,12 @@ unsafe fn trstlp(
                         resold = resmax;
                         resmax = 0.0f64;
                         i__1 = nact;
-                        k = 1 as libc::c_int;
+                        k = 1 as ::core::ffi::c_int;
                         while k <= i__1 {
                             kk = *iact.offset(k as isize);
                             temp = *b.offset(kk as isize);
                             i__2 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__2 {
                                 temp -= *a.offset((i__ + kk * a_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2895,7 +2895,7 @@ unsafe fn trstlp(
                         zdotw = 0.0f64;
                         zdwabs = 0.0f64;
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             temp = *z__.offset((i__ + k * z_dim1) as isize)
                                 * *dxnew.offset(i__ as isize);
@@ -2909,12 +2909,12 @@ unsafe fn trstlp(
                             zdotw = 0.0f64;
                         }
                         *vmultd.offset(k as isize) = zdotw / *zdota.offset(k as isize);
-                        if !(k >= 2 as libc::c_int) {
+                        if !(k >= 2 as ::core::ffi::c_int) {
                             break;
                         }
                         kk = *iact.offset(k as isize);
                         i__1 = *n;
-                        i__ = 1 as libc::c_int;
+                        i__ = 1 as ::core::ffi::c_int;
                         while i__ <= i__1 {
                             *dxnew.offset(i__ as isize) -= *vmultd.offset(k as isize)
                                 * *a.offset((i__ + kk * a_dim1) as isize);
@@ -2928,14 +2928,14 @@ unsafe fn trstlp(
                         *vmultd.offset(nact as isize) = if d__1 >= d__2 { d__1 } else { d__2 };
                     }
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dxnew.offset(i__ as isize) =
                             *dx.offset(i__ as isize) + step * *sdirn.offset(i__ as isize);
                         i__ += 1;
                     }
                     if mcon > nact {
-                        kl = nact + 1 as libc::c_int;
+                        kl = nact + 1 as ::core::ffi::c_int;
                         i__1 = mcon;
                         k = kl;
                         while k <= i__1 {
@@ -2944,7 +2944,7 @@ unsafe fn trstlp(
                             d__1 = *b.offset(kk as isize);
                             sumabs = resmax + (d__1).abs();
                             i__2 = *n;
-                            i__ = 1 as libc::c_int;
+                            i__ = 1 as ::core::ffi::c_int;
                             while i__ <= i__2 {
                                 temp = *a.offset((i__ + kk * a_dim1) as isize)
                                     * *dxnew.offset(i__ as isize);
@@ -2952,19 +2952,19 @@ unsafe fn trstlp(
                                 sumabs += (temp).abs();
                                 i__ += 1;
                             }
-                            acca = sumabs + (sum).abs() * 0.1f32 as libc::c_double;
-                            accb = sumabs + (sum).abs() * 0.2f32 as libc::c_double;
+                            acca = sumabs + (sum).abs() * 0.1f32 as ::core::ffi::c_double;
+                            accb = sumabs + (sum).abs() * 0.2f32 as ::core::ffi::c_double;
                             if sumabs >= acca || acca >= accb {
-                                sum = 0.0f32 as libc::c_double;
+                                sum = 0.0f32 as ::core::ffi::c_double;
                             }
                             *vmultd.offset(k as isize) = sum;
                             k += 1;
                         }
                     }
                     ratio = 1.0f64;
-                    icon = 0 as libc::c_int;
+                    icon = 0 as ::core::ffi::c_int;
                     i__1 = mcon;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         if *vmultd.offset(k as isize) < 0.0f64 {
                             temp = *vmultc.offset(k as isize)
@@ -2978,14 +2978,14 @@ unsafe fn trstlp(
                     }
                     temp = 1.0f64 - ratio;
                     i__1 = *n;
-                    i__ = 1 as libc::c_int;
+                    i__ = 1 as ::core::ffi::c_int;
                     while i__ <= i__1 {
                         *dx.offset(i__ as isize) =
                             temp * *dx.offset(i__ as isize) + ratio * *dxnew.offset(i__ as isize);
                         i__ += 1;
                     }
                     i__1 = mcon;
-                    k = 1 as libc::c_int;
+                    k = 1 as ::core::ffi::c_int;
                     while k <= i__1 {
                         d__1 = 0.0f64;
                         d__2 =
@@ -2996,7 +2996,7 @@ unsafe fn trstlp(
                     if mcon == *m {
                         resmax = resold + ratio * (resmax - resold);
                     }
-                    if icon > 0 as libc::c_int {
+                    if icon > 0 as ::core::ffi::c_int {
                         continue;
                     }
                     if step == stpful {
@@ -3010,7 +3010,7 @@ unsafe fn trstlp(
                     current_block = 11188143500741601598;
                     continue;
                 }
-                *ifull = 0 as libc::c_int;
+                *ifull = 0 as ::core::ffi::c_int;
                 break;
             }
         }


### PR DESCRIPTION
This PR contains  Rust code generated from nlopt cobyla C code 2.10.1 (actually unchanged from 2.7.1) using c2rust 0.22.1
Previous manual edits have been reintegrated.
`libc` dependency is removed, replaced by `core::ffi`.